### PR TITLE
Implement message caching for provider

### DIFF
--- a/llm_server/sources/cache.py
+++ b/llm_server/sources/cache.py
@@ -12,7 +12,12 @@ class Cache:
                 json.dump([], f)
 
         with open(self.cache_file, 'r') as f:
-            self.cache = set(json.load(f))
+            try:
+                self.cache = json.load(f)
+                if not isinstance(self.cache, list):
+                    self.cache = []
+            except json.JSONDecodeError:
+                self.cache = []
 
     def add_message_pair(self, user_message: str, assistant_message: str):
         """Add a user/assistant pair to the cache if not present."""

--- a/sources/cache.py
+++ b/sources/cache.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+class Cache:
+    def __init__(self, cache_dir: str = '.cache', cache_file: str = 'messages.json'):
+        self.cache_dir = Path(cache_dir)
+        self.cache_file = self.cache_dir / cache_file
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if not self.cache_file.exists():
+            self.cache_file.write_text('[]')
+        with open(self.cache_file, 'r') as f:
+            try:
+                self.cache = json.load(f)
+                if not isinstance(self.cache, list):
+                    self.cache = []
+            except json.JSONDecodeError:
+                self.cache = []
+
+    def add_message_pair(self, user_message: str, assistant_message: str) -> None:
+        if not any(entry.get('user') == user_message for entry in self.cache):
+            self.cache.append({'user': user_message, 'assistant': assistant_message})
+            self._save()
+
+    def is_cached(self, user_message: str) -> bool:
+        return any(entry.get('user') == user_message for entry in self.cache)
+
+    def get_cached_response(self, user_message: str):
+        for entry in self.cache:
+            if entry.get('user') == user_message:
+                return entry.get('assistant')
+        return None
+
+    def _save(self) -> None:
+        with open(self.cache_file, 'w') as f:
+            json.dump(self.cache, f, indent=2)

--- a/tests/test_cache_system.py
+++ b/tests/test_cache_system.py
@@ -1,0 +1,52 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from sources.cache import Cache
+from sources.llm_provider import Provider
+
+class TestCache(unittest.TestCase):
+    def setUp(self):
+        self.cache_dir = '.test_cache'
+        self.cache_file = 'cache.json'
+        self.cache = Cache(self.cache_dir, self.cache_file)
+
+    def tearDown(self):
+        if os.path.exists(self.cache_dir):
+            for name in os.listdir(self.cache_dir):
+                os.remove(os.path.join(self.cache_dir, name))
+            os.rmdir(self.cache_dir)
+
+    def test_add_and_retrieve(self):
+        self.cache.add_message_pair('hello', 'hi')
+        self.assertTrue(self.cache.is_cached('hello'))
+        self.assertEqual(self.cache.get_cached_response('hello'), 'hi')
+        # reload to verify persistence
+        new_cache = Cache(self.cache_dir, self.cache_file)
+        self.assertTrue(new_cache.is_cached('hello'))
+        self.assertEqual(new_cache.get_cached_response('hello'), 'hi')
+
+class TestProviderCache(unittest.TestCase):
+    def setUp(self):
+        self.cache_dir = '.prov_cache'
+        self.provider = Provider('test', 'model')
+        self.provider.available_providers['test'] = lambda h, v=False: 'answer'
+        self.provider.cache = Cache(self.cache_dir, 'p.json')
+
+    def tearDown(self):
+        if os.path.exists(self.cache_dir):
+            for name in os.listdir(self.cache_dir):
+                os.remove(os.path.join(self.cache_dir, name))
+            os.rmdir(self.cache_dir)
+
+    def test_provider_uses_cache(self):
+        history = [{'role': 'user', 'content': 'hi'}]
+        res1 = self.provider.respond(history, verbose=False)
+        self.assertEqual(res1, 'answer')
+        # change backend to simulate failure if called again
+        self.provider.available_providers['test'] = lambda h, v=False: 'wrong'
+        res2 = self.provider.respond(history, verbose=False)
+        self.assertEqual(res2, 'answer')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `Cache` utility for persisting responses
- integrate caching into `Provider.respond`
- fix cache initialization in `llm_server`
- add tests covering cache logic and provider usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fae4ec028832bbabbab5949ab3b66