### PR TITLE
Add training episode interface to racing lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,49 @@
 
 [![Visit AgenticSeek](https://img.shields.io/static/v1?label=Website&message=AgenticSeek&color=blue&style=flat-square)](https://fosowl.github.io/agenticSeek.html) ![License](https://img.shields.io/badge/license-GPL--3.0-green) [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/8hGDaME3TC) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fosowl.svg?style=social&label=Update%20%40Fosowl)](https://x.com/Martin993886460) [![GitHub stars](https://img.shields.io/github/stars/Fosowl/agenticSeek?style=social)](https://github.com/Fosowl/agenticSeek/stargazers)
 
+## AgenticSeek Racing Lab
+
+The repository now ships with the AgenticSeek Racing Lab, a physics-driven driving sandbox built on [Three.js](https://threejs.org/). Use it to prototype novel racing policies and evaluate training loops on increasingly complex circuits.
+
+### Highlights
+
+- ⚙️ Lightweight vehicle dynamics model with throttle/brake/steering, surface drag, and off-track penalties.
+- 🏁 Three handcrafted tracks (Training Oval, Switchback Sprint, Spiral Gauntlet) that ramp up technical difficulty.
+- 📊 Real-time HUD telemetry for lap timing, checkpoint progress, and off-track status.
+- 🎮 Instant switching between manual keyboard control and programmatic agents.
+
+### Getting started
+
+1. Open `game/index.html` in a modern browser (Chrome or Firefox recommended).
+2. Use `W`/`A`/`S`/`D` or arrow keys to drive, `Space` to brake, `R` to reset, and `N`/`P` to cycle tracks.
+3. Toggle the follow/overview camera with `C` and watch lap times in the on-screen HUD.
+
+### AI experimentation hooks
+
+- Toggle scripted control with `window.racingSim.useExternalControls()` or revert to manual via `window.racingSim.useManualControls()`.
+- Drive the car with `window.racingSim.setControlInput({ throttle, steer, brake })` where `throttle`/`steer` are in `[-1, 1]` and `brake` in `[0, 1]`.
+- Inspect the simulation state through `window.racingSim.getState()` for telemetry, lap timing, and off-track metrics.
+- Query available tracks with `window.racingSim.getLevels()` and load one using `window.racingSim.loadLevel(index)`.
+- Kick off reinforcement-learning friendly episodes with `window.racingSim.startEpisode({ levelIndex, stepDuration, headless })` which freezes the realtime loop for deterministic stepping.
+- Advance the environment with `window.racingSim.stepEpisode(action)` to receive `{ observation, reward, done, info }` tuples, and finish runs via `window.racingSim.endEpisode()`.
+- Retrieve normalized feature vectors at any time through `window.racingSim.getObservation()` and monitor rewards/progress with `window.racingSim.getTrainingState()`.
+- Review the default reward/termination weights by calling `window.racingSim.getTrainingDefaults()` to tailor custom curricula.
+
+```js
+// Minimal synchronous training loop example
+const obs0 = window.racingSim.startEpisode({ headless: true });
+let done = false;
+while (!done) {
+  const action = { throttle: Math.random() * 2 - 1, steer: Math.random() * 2 - 1, brake: 0 };
+  const step = window.racingSim.stepEpisode(action, { render: false, skipHUD: true });
+  done = step.done;
+}
+const summary = window.racingSim.endEpisode();
+console.log('Episode reward:', summary.cumulativeReward);
+```
+
+Use this sandbox to benchmark reinforcement learning strategies, motion planners, or heuristic controllers against a repeatable suite of racing challenges.
+
 ### Why AgenticSeek ?
 
 * 🔒 Fully Local & Private - Everything runs on your machine — no cloud, no data sharing. Your files, conversations, and searches stay private.

--- a/README.md
+++ b/README.md
@@ -10,48 +10,33 @@
 
 [![Visit AgenticSeek](https://img.shields.io/static/v1?label=Website&message=AgenticSeek&color=blue&style=flat-square)](https://fosowl.github.io/agenticSeek.html) ![License](https://img.shields.io/badge/license-GPL--3.0-green) [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/8hGDaME3TC) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fosowl.svg?style=social&label=Update%20%40Fosowl)](https://x.com/Martin993886460) [![GitHub stars](https://img.shields.io/github/stars/Fosowl/agenticSeek?style=social)](https://github.com/Fosowl/agenticSeek/stargazers)
 
-## AgenticSeek Racing Lab
+## AgenticSeek Three.js Playground
 
-The repository now ships with the AgenticSeek Racing Lab, a physics-driven driving sandbox built on [Three.js](https://threejs.org/). Use it to prototype novel racing policies and evaluate training loops on increasingly complex circuits.
+The repository now ships with the AgenticSeek Three.js Playground, a compact game prototype that showcases a hybrid 2D/3D camera workflow. It is designed to be a friendly starting point for experimenting with physics-lite movement, collectible objectives, and scene composition directly in the browser.
 
 ### Highlights
 
-- ⚙️ Lightweight vehicle dynamics model with throttle/brake/steering, surface drag, and off-track penalties.
-- 🏁 Three handcrafted tracks (Training Oval, Switchback Sprint, Spiral Gauntlet) that ramp up technical difficulty.
-- 📊 Real-time HUD telemetry for lap timing, checkpoint progress, and off-track status.
-- 🎮 Instant switching between manual keyboard control and programmatic agents.
+- 🌌 Fully Three.js powered rendering with dynamic lighting, postured for quick iteration on shaders, level art, or mechanics.
+- 🔄 Instant switching between a cinematic third-person chase view and a top-down tactical view to explore 2D/3D gameplay ideas.
+- 🧭 Responsive player controls with momentum, damping, and boundary checks so you can focus on interaction design instead of boilerplate setup.
+- 💠 Procedurally scattered "energy shards" that respawn on demand, making it easy to prototype scoring systems and progression loops.
 
 ### Getting started
 
 1. Open `game/index.html` in a modern browser (Chrome or Firefox recommended).
-2. Use `W`/`A`/`S`/`D` or arrow keys to drive, `Space` to brake, `R` to reset, and `N`/`P` to cycle tracks.
-3. Toggle the follow/overview camera with `C` and watch lap times in the on-screen HUD.
+2. Use `W`/`A`/`S`/`D` or the arrow keys to glide across the platform. Hold `Shift` for a short speed boost and tap `Space` to quickly brake.
+3. Press `V` to toggle between the third-person and top-down cameras, and `R` to respawn collectibles if you want another run.
 
-### AI experimentation hooks
+### Scripting hooks
 
-- Toggle scripted control with `window.racingSim.useExternalControls()` or revert to manual via `window.racingSim.useManualControls()`.
-- Drive the car with `window.racingSim.setControlInput({ throttle, steer, brake })` where `throttle`/`steer` are in `[-1, 1]` and `brake` in `[0, 1]`.
-- Inspect the simulation state through `window.racingSim.getState()` for telemetry, lap timing, and off-track metrics.
-- Query available tracks with `window.racingSim.getLevels()` and load one using `window.racingSim.loadLevel(index)`.
-- Kick off reinforcement-learning friendly episodes with `window.racingSim.startEpisode({ levelIndex, stepDuration, headless })` which freezes the realtime loop for deterministic stepping.
-- Advance the environment with `window.racingSim.stepEpisode(action)` to receive `{ observation, reward, done, info }` tuples, and finish runs via `window.racingSim.endEpisode()`.
-- Retrieve normalized feature vectors at any time through `window.racingSim.getObservation()` and monitor rewards/progress with `window.racingSim.getTrainingState()`.
-- Review the default reward/termination weights by calling `window.racingSim.getTrainingDefaults()` to tailor custom curricula.
+The playground exposes a tiny API on `window.playgroundSim` so you can plug in custom logic, UI, or training loops without modifying the core script:
 
-```js
-// Minimal synchronous training loop example
-const obs0 = window.racingSim.startEpisode({ headless: true });
-let done = false;
-while (!done) {
-  const action = { throttle: Math.random() * 2 - 1, steer: Math.random() * 2 - 1, brake: 0 };
-  const step = window.racingSim.stepEpisode(action, { render: false, skipHUD: true });
-  done = step.done;
-}
-const summary = window.racingSim.endEpisode();
-console.log('Episode reward:', summary.cumulativeReward);
-```
+- `window.playgroundSim.getState()` returns the current player pose, velocity, collected count, elapsed time, and active view.
+- `window.playgroundSim.reset()` recenters the player and scatters a fresh batch of collectibles.
+- `window.playgroundSim.toggleView(mode)` switches between the built-in `"chase"` and `"orthographic"` cameras, or accepts `"auto"` to cycle modes.
+- `window.playgroundSim.spawnCollectibles(count)` re-populates the arena with a specific number of shards.
 
-Use this sandbox to benchmark reinforcement learning strategies, motion planners, or heuristic controllers against a repeatable suite of racing challenges.
+Use these helpers to wire in your own UI overlays, automate playtests, or experiment with reinforcement learning agents that reason over both 2D and 3D perspectives.
 
 ### Why AgenticSeek ?
 

--- a/game/game.js
+++ b/game/game.js
@@ -1,1290 +1,384 @@
-const TRACK_LEVELS = [
-  {
-    name: 'Training Oval',
-    difficulty: 'Novice',
-    description:
-      'Wide, sweeping turns that emphasize smooth throttle control and stable steering. Ideal for baseline policy evaluation.',
-    color: 0x3f7bff,
-    width: 1.9,
-    checkpointRadius: 2.7,
-    spawn: { position: [0, 0.25, -11], heading: 0 },
-    path: [
-      [0, -12],
-      [5, -11],
-      [10, -7],
-      [12, 0],
-      [10, 7],
-      [5, 11],
-      [0, 12],
-      [-5, 11],
-      [-10, 7],
-      [-12, 0],
-      [-10, -7],
-      [-5, -11],
-    ],
-    checkpoints: [
-      [0, -11],
-      [9, 0],
-      [0, 11],
-      [-9, 0],
-    ],
-  },
-  {
-    name: 'Switchback Sprint',
-    difficulty: 'Intermediate',
-    description:
-      'Tight chicanes and hairpins push braking and steering precision. Perfect for experimenting with look-ahead controllers.',
-    color: 0x3ad7a3,
-    width: 1.45,
-    checkpointRadius: 2.2,
-    spawn: { position: [-11, 0.25, -7], heading: Math.PI / 6 },
-    path: [
-      [-12, -8],
-      [-8, -11],
-      [-2, -9],
-      [4, -7],
-      [10, -3],
-      [12, 2],
-      [8, 6],
-      [2, 9],
-      [-4, 10],
-      [-10, 7],
-      [-12, 1],
-      [-8, -3],
-    ],
-    checkpoints: [
-      [-11, -7],
-      [-2, -3],
-      [7, 1],
-      [1, 8],
-      [-8, 5],
-    ],
-  },
-  {
-    name: 'Spiral Gauntlet',
-    difficulty: 'Advanced',
-    description:
-      'A narrowing spiral with sweeping radius changes that reward predictive control policies and adaptive braking strategies.',
-    color: 0xff7a4d,
-    width: 1.15,
-    checkpointRadius: 2.0,
-    spawn: { position: [0, 0.25, -9], heading: 0 },
-    path: [
-      [0, -10],
-      [6, -8],
-      [10, -2],
-      [9, 4],
-      [5, 9],
-      [-1, 10],
-      [-7, 8],
-      [-10, 3],
-      [-9, -3],
-      [-4, -8],
-      [2, -9],
-      [7, -4],
-      [6, 2],
-      [2, 6],
-      [-3, 6],
-      [-6, 2],
-      [-5, -3],
-      [-1, -6],
-      [3, -6],
-      [5, -3],
-      [3, 0],
-      [0, 2],
-      [-2, 0],
-      [-1, -3],
-    ],
-    checkpoints: [
-      [0, -9],
-      [8, -1],
-      [2, 7],
-      [-7, 5],
-      [-2, -5],
-    ],
-  },
-];
+(() => {
+  if (typeof THREE === 'undefined') {
+    console.error('Three.js must be loaded before game.js');
+    return;
+  }
 
-const TRAINING_DEFAULTS = {
-  stepDuration: 1 / 60,
-  reward: {
-    progress: 1,
-    centerline: 0.6,
-    offTrack: 4,
-    smoothness: 0.3,
-    brake: 0.2,
-    checkpointBonus: 8,
-    lapBonus: 25,
-  },
-  termination: {
-    offTrackSteps: 120,
-    noProgressSteps: 240,
-    maxSteps: 5400,
-    progressThreshold: 0.0002,
-  },
-};
+  const canvas = document.getElementById('gameCanvas');
+  if (!canvas) {
+    console.error('Missing #gameCanvas element');
+    return;
+  }
 
-class RacingLab {
-  constructor() {
-    this.scene = new THREE.Scene();
-    this.scene.background = new THREE.Color(0x0f1017);
-    this.scene.fog = new THREE.Fog(0x06070c, 60, 120);
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
 
-    this.camera = new THREE.PerspectiveCamera(
-      60,
-      window.innerWidth / window.innerHeight,
-      0.1,
-      250
-    );
-    this.camera.position.set(0, 14, 18);
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x05070e);
 
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
-    this.renderer.setPixelRatio(window.devicePixelRatio);
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-    document.body.appendChild(this.renderer.domElement);
+  const hemiLight = new THREE.HemisphereLight(0x6ea9ff, 0x0b101f, 0.55);
+  scene.add(hemiLight);
 
-    this.cameraMode = 'follow';
+  const keyLight = new THREE.DirectionalLight(0xfff4de, 0.95);
+  keyLight.position.set(6, 9, 5);
+  keyLight.castShadow = false;
+  scene.add(keyLight);
 
-    this.lastTime = performance.now();
-    this.currentTimeMs = 0;
-    this.lastTimestamp = this.currentTimeMs;
-    this.simulationPaused = false;
-    this.trainingSession = null;
+  const fillLight = new THREE.DirectionalLight(0x7bc4ff, 0.35);
+  fillLight.position.set(-4, 6, -7);
+  scene.add(fillLight);
 
-    this.lastTrackProjection = {
-      t: 0,
-      distance: 0,
-      closestPoint: new THREE.Vector3(),
-      tangent: new THREE.Vector3(0, 0, 1),
+  const arenaRadius = 16;
+
+  const arenaMaterial = new THREE.MeshStandardMaterial({
+    color: 0x101b32,
+    roughness: 0.85,
+    metalness: 0.05,
+  });
+  const arena = new THREE.Mesh(new THREE.CylinderGeometry(arenaRadius, arenaRadius, 0.6, 64), arenaMaterial);
+  arena.receiveShadow = true;
+  arena.position.y = -0.3;
+  scene.add(arena);
+
+  const platformMaterial = new THREE.MeshStandardMaterial({
+    color: 0x16274a,
+    roughness: 0.6,
+    metalness: 0.35,
+    emissive: 0x0a1326,
+    emissiveIntensity: 0.35,
+  });
+  const platform = new THREE.Mesh(new THREE.CylinderGeometry(arenaRadius * 0.96, arenaRadius * 0.96, 0.1, 64), platformMaterial);
+  platform.receiveShadow = true;
+  platform.position.y = 0;
+  scene.add(platform);
+
+  const gridHelper = new THREE.GridHelper(arenaRadius * 1.8, 24, 0x3b74bf, 0x1c2c4b);
+  gridHelper.position.y = 0.051;
+  scene.add(gridHelper);
+
+  const rimGeometry = new THREE.TorusGeometry(arenaRadius * 1.02, 0.12, 16, 64);
+  const rimMaterial = new THREE.MeshBasicMaterial({ color: 0x1f88ff, opacity: 0.6, transparent: true });
+  const rim = new THREE.Mesh(rimGeometry, rimMaterial);
+  rim.rotation.x = Math.PI / 2;
+  rim.position.y = 0.05;
+  scene.add(rim);
+
+  const playerMaterial = new THREE.MeshStandardMaterial({
+    color: 0x47c4ff,
+    emissive: 0x134b7c,
+    metalness: 0.45,
+    roughness: 0.3,
+  });
+  const player = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.9, 0.9), playerMaterial);
+  player.position.set(0, 0.45, 0);
+  scene.add(player);
+
+  const trailRing = new THREE.Mesh(
+    new THREE.RingGeometry(0.55, 0.75, 32),
+    new THREE.MeshBasicMaterial({ color: 0x2fbfff, opacity: 0.7, transparent: true })
+  );
+  trailRing.rotation.x = -Math.PI / 2;
+  trailRing.position.y = 0.02;
+  scene.add(trailRing);
+
+  const columnMaterial = new THREE.MeshStandardMaterial({
+    color: 0x1a2745,
+    metalness: 0.2,
+    roughness: 0.6,
+  });
+  const pillarPositions = [
+    new THREE.Vector3(7, 0, 7),
+    new THREE.Vector3(-7, 0, 7),
+    new THREE.Vector3(-7, 0, -7),
+    new THREE.Vector3(7, 0, -7),
+  ];
+  pillarPositions.forEach((pos) => {
+    const height = 2.6 + Math.random() * 1.2;
+    const pillar = new THREE.Mesh(new THREE.CylinderGeometry(0.35, 0.35, height, 24), columnMaterial);
+    pillar.position.set(pos.x, height / 2, pos.z);
+    scene.add(pillar);
+  });
+
+  const aspect = window.innerWidth / window.innerHeight;
+
+  const chaseCamera = new THREE.PerspectiveCamera(60, aspect, 0.1, 100);
+  chaseCamera.position.set(6, 5.5, 6.5);
+  chaseCamera.lookAt(player.position);
+
+  const orthoSize = 12;
+  const orthoCamera = new THREE.OrthographicCamera(
+    (-orthoSize * aspect) / 2,
+    (orthoSize * aspect) / 2,
+    orthoSize / 2,
+    -orthoSize / 2,
+    0.1,
+    100
+  );
+  orthoCamera.position.set(0, 20, 0);
+  orthoCamera.lookAt(player.position);
+  orthoCamera.up.set(0, 0, -1);
+
+  let activeCamera = chaseCamera;
+  let cameraMode = 'chase';
+
+  const clock = new THREE.Clock();
+  let elapsedTime = 0;
+
+  const keys = new Map();
+
+  const velocity = new THREE.Vector3();
+  const scratch = new THREE.Vector3();
+
+  const timeEl = document.getElementById('timeValue');
+  const scoreEl = document.getElementById('scoreValue');
+  const totalEl = document.getElementById('totalValue');
+  const viewEl = document.getElementById('viewLabel');
+  const messageEl = document.getElementById('message');
+
+  const collectiblesGroup = new THREE.Group();
+  scene.add(collectiblesGroup);
+  let collectibles = [];
+
+  const collectibleGeometry = new THREE.OctahedronGeometry(0.35);
+  const baseCollectibleMaterial = new THREE.MeshStandardMaterial({
+    color: 0xffc857,
+    emissive: 0x663300,
+    emissiveIntensity: 0.75,
+    roughness: 0.4,
+    metalness: 0.3,
+  });
+
+  function createCollectible() {
+    const material = baseCollectibleMaterial.clone();
+    material.color.offsetHSL(Math.random() * 0.08 - 0.04, 0, Math.random() * 0.1 - 0.05);
+    const mesh = new THREE.Mesh(collectibleGeometry, material);
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.userData = {
+      collected: false,
+      phase: Math.random() * Math.PI * 2,
     };
-
-    this.keys = {};
-    this.externalControl = { throttle: 0, brake: 0, steer: 0 };
-    this.controlMode = 'manual';
-
-    this.params = {
-      acceleration: 10.5,
-      reverseAcceleration: 6.0,
-      brakeStrength: 18,
-      drag: 0.42,
-      rollingResistance: 1.35,
-      offTrackResistance: 7.5,
-      maxSpeed: 22,
-      maxReverseSpeed: 7,
-      maxSteer: THREE.MathUtils.degToRad(34),
-      steerRate: THREE.MathUtils.degToRad(155),
-      wheelBase: 2.6,
-    };
-
-    this._buildEnvironment();
-    this.car = this._buildCar();
-
-    this.checkpointMaterials = {
-      idle: new THREE.MeshStandardMaterial({
-        color: 0x1d2534,
-        transparent: true,
-        opacity: 0.35,
-        metalness: 0.1,
-        roughness: 0.6,
-      }),
-      active: new THREE.MeshStandardMaterial({
-        color: 0xffd166,
-        emissive: 0x7d4b00,
-        emissiveIntensity: 0.7,
-        transparent: true,
-        opacity: 0.85,
-      }),
-      passed: new THREE.MeshStandardMaterial({
-        color: 0x6cf5b3,
-        emissive: 0x0e5431,
-        emissiveIntensity: 0.65,
-        transparent: true,
-        opacity: 0.65,
-      }),
-    };
-
-    this.trackMesh = null;
-    this.startLine = null;
-    this.checkpoints = [];
-    this.trackSamples = [];
-
-    this.activeCheckpoint = 0;
-    this.offTrack = false;
-    this.distanceFromCenter = 0;
-
-    this.lapTimes = [];
-    this.lastLapTime = null;
-    this.bestLapTime = null;
-    this.lapStartTime = null;
-
-    this.hud = {
-      telemetry: document.getElementById('telemetry'),
-      instructions: document.getElementById('instructions'),
-      flash: document.getElementById('lapFlash'),
-    };
-
-    this.lapFlashTimeout = null;
-
-    window.addEventListener('resize', () => this._onResize());
-    window.addEventListener('keydown', (e) => this._handleKeyDown(e));
-    window.addEventListener('keyup', (e) => this._handleKeyUp(e));
-
-    this.loadLevel(0);
-    this.animate();
+    return mesh;
   }
 
-  _buildEnvironment() {
-    const ambient = new THREE.AmbientLight(0xb9c5ff, 0.22);
-    const hemi = new THREE.HemisphereLight(0xaec6ff, 0x0b0d13, 0.75);
-    const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
-    dirLight.position.set(18, 26, 12);
-
-    this.scene.add(ambient, hemi, dirLight);
-
-    const groundGeometry = new THREE.PlaneGeometry(220, 220, 10, 10);
-    const groundMaterial = new THREE.MeshStandardMaterial({
-      color: 0x101522,
-      roughness: 0.9,
-      metalness: 0.05,
-    });
-    const ground = new THREE.Mesh(groundGeometry, groundMaterial);
-    ground.rotation.x = -Math.PI / 2;
-    ground.position.y = 0;
-    this.scene.add(ground);
-
-    const grid = new THREE.GridHelper(220, 110, 0x22304a, 0x131a2b);
-    grid.position.y = 0.01;
-    this.scene.add(grid);
+  function randomPoint() {
+    const radius = arenaRadius * 0.75;
+    let x = 0;
+    let z = 0;
+    let attempts = 0;
+    do {
+      const angle = Math.random() * Math.PI * 2;
+      const r = 2.5 + Math.random() * (radius - 2.5);
+      x = Math.cos(angle) * r;
+      z = Math.sin(angle) * r;
+      attempts += 1;
+    } while (scratch.set(x, 0, z).distanceToSquared(player.position) < 4 && attempts < 8);
+    return { x, z };
   }
 
-  _buildCar() {
-    const group = new THREE.Group();
-
-    const chassisGeometry = new THREE.BoxGeometry(1.4, 0.4, 2.6);
-    const chassisMaterial = new THREE.MeshStandardMaterial({
-      color: 0xff5533,
-      metalness: 0.35,
-      roughness: 0.45,
-    });
-    const chassis = new THREE.Mesh(chassisGeometry, chassisMaterial);
-    chassis.position.y = 0.2;
-    group.add(chassis);
-
-    const canopyGeometry = new THREE.BoxGeometry(1.05, 0.35, 1.2);
-    const canopyMaterial = new THREE.MeshStandardMaterial({
-      color: 0xf8f9fb,
-      metalness: 0.1,
-      roughness: 0.2,
-    });
-    const canopy = new THREE.Mesh(canopyGeometry, canopyMaterial);
-    canopy.position.set(0, 0.5, -0.1);
-    group.add(canopy);
-
-    const wheelGeometry = new THREE.CylinderGeometry(0.35, 0.35, 0.25, 22);
-    wheelGeometry.rotateZ(Math.PI / 2);
-    const wheelMaterial = new THREE.MeshStandardMaterial({
-      color: 0x0c0c0f,
-      roughness: 0.9,
-    });
-    const wheelOffsets = [
-      [0.7, 0, 1.1],
-      [-0.7, 0, 1.1],
-      [0.7, 0, -1.1],
-      [-0.7, 0, -1.1],
-    ];
-    wheelOffsets.forEach(([x, y, z]) => {
-      const wheel = new THREE.Mesh(wheelGeometry.clone(), wheelMaterial);
-      wheel.position.set(x, 0.15 + y, z);
-      group.add(wheel);
-    });
-
-    group.position.set(0, 0.25, 0);
-    this.scene.add(group);
-
-    return {
-      mesh: group,
-      position: group.position,
-      speed: 0,
-      heading: 0,
-      steerAngle: 0,
-    };
+  function scatterCollectibles(count = 8) {
+    collectibles.forEach((c) => collectiblesGroup.remove(c.mesh));
+    collectibles = [];
+    for (let i = 0; i < count; i += 1) {
+      const mesh = createCollectible();
+      const { x, z } = randomPoint();
+      mesh.position.set(x, 0.45, z);
+      collectiblesGroup.add(mesh);
+      collectibles.push({ mesh, collected: false });
+    }
+    totalEl.textContent = String(collectibles.length);
+    scoreEl.textContent = '0';
+    messageEl.textContent = '';
   }
 
-  loadLevel(index) {
-    const levelIndex = THREE.MathUtils.euclideanModulo(index, TRACK_LEVELS.length);
-    const level = TRACK_LEVELS[levelIndex];
-
-    if (this.trackMesh) {
-      this.scene.remove(this.trackMesh);
-      this.trackMesh.geometry.dispose();
-      this.trackMesh.material.dispose();
-      this.trackMesh = null;
-    }
-
-    if (this.startLine) {
-      this.scene.remove(this.startLine);
-      this.startLine.geometry.dispose();
-      this.startLine.material.dispose();
-      this.startLine = null;
-    }
-
-    if (this.checkpoints.length) {
-      this.checkpoints.forEach((checkpoint) => {
-        this.scene.remove(checkpoint.mesh);
-        checkpoint.mesh.geometry.dispose();
-      });
-    }
-    this.checkpoints = [];
-
-    this.levelIndex = levelIndex;
-    this.level = level;
-
-    const pathVectors = level.path.map(([x, z]) => new THREE.Vector3(x, 0.05, z));
-    this.levelCurve = new THREE.CatmullRomCurve3(pathVectors, true, 'catmullrom', 0.1);
-    this.trackLength = this.levelCurve.getLength();
-
-    const segments = Math.max(pathVectors.length * 12, 180);
-    const trackGeometry = new THREE.TubeGeometry(
-      this.levelCurve,
-      segments,
-      level.width,
-      24,
-      true
-    );
-    const trackMaterial = new THREE.MeshStandardMaterial({
-      color: level.color,
-      roughness: 0.35,
-      metalness: 0.25,
-      emissive: new THREE.Color(level.color).multiplyScalar(0.1),
-    });
-    this.trackMesh = new THREE.Mesh(trackGeometry, trackMaterial);
-    this.trackMesh.position.y = 0.08;
-    this.trackMesh.scale.y = 0.2;
-    this.scene.add(this.trackMesh);
-
-    this.trackSamples = [];
-    const sampleCount = 720;
-    for (let i = 0; i < sampleCount; i += 1) {
-      const t = i / sampleCount;
-      const point = this.levelCurve.getPointAt(t);
-      this.trackSamples.push({ point, t });
-    }
-
-    const checkpointGeometry = new THREE.CylinderGeometry(
-      level.checkpointRadius,
-      level.checkpointRadius,
-      0.2,
-      32,
-      1,
-      true
-    );
-    level.checkpoints.forEach(([x, z], idx) => {
-      const mesh = new THREE.Mesh(checkpointGeometry.clone(), this.checkpointMaterials.idle);
-      mesh.position.set(x, 0.12, z);
-      mesh.rotation.x = Math.PI / 2;
-      this.scene.add(mesh);
-
-      this.checkpoints.push({
-        index: idx,
-        position: new THREE.Vector3(x, 0.1, z),
-        mesh,
-      });
-    });
-    checkpointGeometry.dispose();
-
-    if (this.checkpoints.length > 1) {
-      const start = this.checkpoints[0].position.clone();
-      const next = this.checkpoints[1].position.clone();
-      const direction = next.clone().sub(start).normalize();
-      const angle = Math.atan2(direction.x, direction.z) + Math.PI / 2;
-      const startGeometry = new THREE.PlaneGeometry(level.width * 2.2, 0.8);
-      const startMaterial = new THREE.MeshBasicMaterial({
-        color: 0xffffff,
-        transparent: true,
-        opacity: 0.55,
-        side: THREE.DoubleSide,
-      });
-      this.startLine = new THREE.Mesh(startGeometry, startMaterial);
-      this.startLine.rotation.x = -Math.PI / 2;
-      this.startLine.rotation.y = angle;
-      this.startLine.position.copy(start);
-      this.startLine.position.y = 0.11;
-      this.scene.add(this.startLine);
-    }
-
-    this.activeCheckpoint = 0;
-    this.offTrack = false;
-    this.distanceFromCenter = 0;
-
-    this.lapTimes = [];
-    this.lastLapTime = null;
-    this.bestLapTime = null;
-    this.lapStartTime = null;
-
-    this._updateInstructions();
-    this.resetCar({ preserveLapTimes: false });
+  function setCameraMode(mode) {
+    const next = mode === 'auto' ? (cameraMode === 'chase' ? 'orthographic' : 'chase') : mode;
+    if (next === cameraMode) return;
+    cameraMode = next;
+    activeCamera = cameraMode === 'chase' ? chaseCamera : orthoCamera;
+    viewEl.textContent = cameraMode === 'chase' ? 'Chase' : 'Top-down';
   }
 
-  resetCar({ preserveLapTimes = true } = {}) {
-    if (!this.level) return;
-
-    const [x, y, z] = this.level.spawn.position;
-    this.car.position.set(x, y, z);
-    this.car.heading = this.level.spawn.heading;
-    this.car.speed = 0;
-    this.car.steerAngle = 0;
-    this.car.mesh.position.copy(this.car.position);
-    this.car.mesh.rotation.set(0, this.car.heading, 0);
-
-    this.activeCheckpoint = 0;
-    this.offTrack = false;
-
-    this.checkpoints.forEach((checkpoint) => {
-      checkpoint.mesh.material = this.checkpointMaterials.idle;
-    });
-    if (this.checkpoints[0]) {
-      this.checkpoints[0].mesh.material = this.checkpointMaterials.active;
-    }
-
-    if (!preserveLapTimes) {
-      this.lapTimes = [];
-      this.lastLapTime = null;
-      this.bestLapTime = null;
-    }
-    this.lapStartTime = this.currentTimeMs;
-  }
-
-  setControlMode(mode) {
-    this.controlMode = mode === 'external' ? 'external' : 'manual';
-    if (this.controlMode === 'manual') {
-      this.externalControl = { throttle: 0, brake: 0, steer: 0 };
+  function handleKeyDown(event) {
+    keys.set(event.code, true);
+    if (event.code === 'KeyV') {
+      setCameraMode('auto');
+    } else if (event.code === 'KeyR') {
+      resetGame();
     }
   }
 
-  setExternalControl(control = {}) {
-    this.externalControl = this._sanitizeControlInput(control);
-    if (control.reset === true) {
-      this.resetCar({ preserveLapTimes: true });
+  function handleKeyUp(event) {
+    keys.set(event.code, false);
+  }
+
+  window.addEventListener('keydown', handleKeyDown);
+  window.addEventListener('keyup', handleKeyUp);
+
+  function clampToArena(position) {
+    const distance = Math.sqrt(position.x * position.x + position.z * position.z);
+    if (distance > arenaRadius * 0.94) {
+      const scale = (arenaRadius * 0.94) / distance;
+      position.x *= scale;
+      position.z *= scale;
+      velocity.x *= 0.3;
+      velocity.z *= 0.3;
     }
   }
 
-  setCameraMode(mode) {
-    this.cameraMode = mode === 'overview' ? 'overview' : 'follow';
-  }
-
-  toggleCameraMode() {
-    this.setCameraMode(this.cameraMode === 'follow' ? 'overview' : 'follow');
-  }
-
-  _handleKeyDown(event) {
-    const key = event.key.toLowerCase();
-    if (
-      ['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' '].includes(key) ||
-      ['w', 'a', 's', 'd'].includes(key)
-    ) {
-      event.preventDefault();
-    }
-
-    switch (key) {
-      case 'r':
-        this.resetCar({ preserveLapTimes: true });
-        return;
-      case 'n':
-        this.loadLevel(this.levelIndex + 1);
-        return;
-      case 'p':
-        this.loadLevel(this.levelIndex - 1);
-        return;
-      case 'm':
-        this.setControlMode('manual');
-        return;
-      case 'g':
-        this.setControlMode('external');
-        return;
-      case 'c':
-        this.toggleCameraMode();
-        return;
-      default:
-        break;
-    }
-
-    this.keys[key] = true;
-  }
-
-  _handleKeyUp(event) {
-    const key = event.key.toLowerCase();
-    this.keys[key] = false;
-  }
-
-  _isKeyActive(key) {
-    return Boolean(this.keys[key]);
-  }
-
-  _sanitizeControlInput(control = {}) {
-    return {
-      throttle: THREE.MathUtils.clamp(
-        control.throttle ?? control.accelerate ?? control.forward ?? 0,
-        -1,
-        1
-      ),
-      brake: THREE.MathUtils.clamp(control.brake ?? control.handbrake ?? 0, 0, 1),
-      steer: THREE.MathUtils.clamp(control.steer ?? control.turn ?? 0, -1, 1),
-    };
-  }
-
-  resolveControls() {
-    if (this.controlMode === 'external') {
-      return { ...this.externalControl };
-    }
-
-    let throttle = 0;
-    if (this._isKeyActive('w') || this._isKeyActive('arrowup')) throttle += 1;
-    if (this._isKeyActive('s') || this._isKeyActive('arrowdown')) throttle -= 1;
-
-    let steer = 0;
-    if (this._isKeyActive('a') || this._isKeyActive('arrowleft')) steer -= 1;
-    if (this._isKeyActive('d') || this._isKeyActive('arrowright')) steer += 1;
-
-    const brake = this._isKeyActive(' ');
-
-    return {
-      throttle: THREE.MathUtils.clamp(throttle, -1, 1),
-      steer: THREE.MathUtils.clamp(steer, -1, 1),
-      brake: brake ? 1 : 0,
-    };
-  }
-
-  updatePhysics(dt, controlOverride) {
-    const controls = controlOverride
-      ? this._sanitizeControlInput(controlOverride)
-      : this.resolveControls();
-    const steerTarget = THREE.MathUtils.clamp(controls.steer, -1, 1) * this.params.maxSteer;
-    const steerDelta = steerTarget - this.car.steerAngle;
-    const maxSteerChange = this.params.steerRate * dt;
-    this.car.steerAngle += THREE.MathUtils.clamp(steerDelta, -maxSteerChange, maxSteerChange);
-
-    const throttleInput = THREE.MathUtils.clamp(controls.throttle ?? 0, -1, 1);
-    const brakeInput = THREE.MathUtils.clamp(controls.brake ?? 0, 0, 1);
-
-    let acceleration = 0;
-    if (throttleInput >= 0) {
-      acceleration += throttleInput * this.params.acceleration;
-    } else {
-      acceleration += throttleInput * this.params.reverseAcceleration;
-    }
-
-    if (brakeInput > 0) {
-      acceleration -= Math.sign(this.car.speed) * brakeInput * this.params.brakeStrength;
-    }
-
-    const drag = this.params.drag * this.car.speed * Math.abs(this.car.speed);
-    const rolling = this.params.rollingResistance * Math.sign(this.car.speed);
-    acceleration -= drag;
-    if (Math.abs(this.car.speed) > 0.05) {
-      acceleration -= rolling;
-    }
-
-    if (this.offTrack) {
-      acceleration -= Math.sign(this.car.speed) * this.params.offTrackResistance;
-    }
-
-    this.car.speed += acceleration * dt;
-    this.car.speed = THREE.MathUtils.clamp(
-      this.car.speed,
-      -this.params.maxReverseSpeed,
-      this.params.maxSpeed
-    );
-    if (Math.abs(this.car.speed) < 0.01 && throttleInput === 0 && brakeInput === 0) {
-      this.car.speed = 0;
-    }
-
-    const forward = new THREE.Vector3(
-      Math.sin(this.car.heading),
+  function updatePlayer(dt) {
+    scratch.set(
+      (keys.get('KeyD') || keys.get('ArrowRight') ? 1 : 0) - (keys.get('KeyA') || keys.get('ArrowLeft') ? 1 : 0),
       0,
-      Math.cos(this.car.heading)
+      (keys.get('KeyS') || keys.get('ArrowDown') ? 1 : 0) - (keys.get('KeyW') || keys.get('ArrowUp') ? 1 : 0)
     );
-    this.car.position.addScaledVector(forward, this.car.speed * dt);
-    this.car.position.y = this.level.spawn.position[1];
 
-    const angularVelocity = (this.car.speed / this.params.wheelBase) * Math.tan(this.car.steerAngle);
-    this.car.heading += angularVelocity * dt;
-    this.car.mesh.position.copy(this.car.position);
-    this.car.mesh.rotation.set(0, this.car.heading, 0);
+    if (scratch.lengthSq() > 0) {
+      scratch.normalize();
+    }
+
+    const boost = keys.get('ShiftLeft') || keys.get('ShiftRight') ? 1.6 : 1;
+    const acceleration = 9 * boost;
+    velocity.x += scratch.x * acceleration * dt;
+    velocity.z += scratch.z * acceleration * dt;
+
+    const baseDamping = scratch.lengthSq() > 0 ? 3.8 : 6.2;
+    const brakeDamping = keys.get('Space') ? 18 : 0;
+    const damping = Math.max(0, 1 - Math.min(0.98, (baseDamping + brakeDamping) * dt));
+    velocity.multiplyScalar(damping);
+
+    player.position.addScaledVector(velocity, dt);
+    clampToArena(player.position);
+
+    trailRing.position.set(player.position.x, 0.02, player.position.z);
+
+    if (velocity.lengthSq() > 0.001) {
+      player.rotation.y = Math.atan2(velocity.x, velocity.z);
+    }
   }
 
-  handleCheckpoints() {
-    if (!this.level || !this.checkpoints.length) return;
-
-    const checkpoint = this.checkpoints[this.activeCheckpoint];
-    if (!checkpoint) return;
-
-    const distance = checkpoint.position.distanceTo(this.car.position);
-    if (distance <= this.level.checkpointRadius) {
-      checkpoint.mesh.material = this.checkpointMaterials.passed;
-      this.activeCheckpoint += 1;
-
-      if (this.activeCheckpoint >= this.checkpoints.length) {
-        const now = this.currentTimeMs;
-        if (this.lapStartTime) {
-          const lapMs = now - this.lapStartTime;
-          this.lapTimes.push(lapMs);
-          this.lastLapTime = lapMs;
-          this.bestLapTime = this.bestLapTime ? Math.min(this.bestLapTime, lapMs) : lapMs;
-          this._showLapFlash(lapMs);
+  function updateCollectibles(dt, time) {
+    let collectedCount = 0;
+    collectibles.forEach((item) => {
+      const mesh = item.mesh;
+      if (!item.collected) {
+        const distanceSq = mesh.position.distanceToSquared(player.position);
+        if (distanceSq < 0.8) {
+          item.collected = true;
+          mesh.visible = false;
+          scoreEl.textContent = String(Number(scoreEl.textContent) + 1);
         }
-        this.lapStartTime = now;
-        this.activeCheckpoint = 0;
-        this.checkpoints.forEach((cp, idx) => {
-          cp.mesh.material = idx === 0 ? this.checkpointMaterials.active : this.checkpointMaterials.idle;
-        });
+      }
+
+      if (item.collected) {
+        collectedCount += 1;
+        mesh.rotation.y += dt * 2.5;
       } else {
-        const nextCheckpoint = this.checkpoints[this.activeCheckpoint];
-        nextCheckpoint.mesh.material = this.checkpointMaterials.active;
-        if (!this.lapStartTime) {
-          this.lapStartTime = this.currentTimeMs;
-        }
+        mesh.position.y = 0.45 + Math.sin(time * 2 + mesh.userData.phase) * 0.12;
+        mesh.rotation.y += dt * 1.5;
       }
+    });
+
+    if (collectibles.length > 0 && collectedCount === collectibles.length) {
+      messageEl.textContent = 'All shards collected! Press R to respawn.';
     }
   }
 
-  updateOffTrack() {
-    if (!this.trackSamples.length) {
-      this.offTrack = false;
-      this.distanceFromCenter = 0;
-      this.lastTrackProjection = {
-        t: 0,
-        distance: 0,
-        closestPoint: this.car.position.clone(),
-        tangent: new THREE.Vector3(0, 0, 1),
-      };
-      return;
-    }
+  const chaseOffset = new THREE.Vector3(0, 3.4, 6.2);
+  const lookOffset = new THREE.Vector3(0, 1.1, 0);
 
-    const projection = this._computeTrackProjection(this.car.position);
-    this.lastTrackProjection = projection;
-    this.distanceFromCenter = projection.distance;
-    this.offTrack = projection.distance > this.level.width * 1.15;
-  }
-
-  _computeTrackProjection(position = this.car.position) {
-    if (!this.trackSamples.length) {
-      return {
-        t: 0,
-        distance: 0,
-        closestPoint: position.clone(),
-        tangent: new THREE.Vector3(0, 0, 1),
-      };
-    }
-
-    let bestSample = this.trackSamples[0];
-    let minDistanceSq = Infinity;
-    for (let i = 0; i < this.trackSamples.length; i += 1) {
-      const sample = this.trackSamples[i];
-      const dx = position.x - sample.point.x;
-      const dz = position.z - sample.point.z;
-      const distSq = dx * dx + dz * dz;
-      if (distSq < minDistanceSq) {
-        minDistanceSq = distSq;
-        bestSample = sample;
-      }
-    }
-
-    let tangent;
-    if (this.levelCurve && typeof this.levelCurve.getTangentAt === 'function') {
-      tangent = this.levelCurve.getTangentAt(bestSample.t).clone();
-    } else if (this.levelCurve && typeof this.levelCurve.getTangent === 'function') {
-      tangent = this.levelCurve.getTangent(bestSample.t).clone();
-    } else {
-      tangent = new THREE.Vector3(0, 0, 1);
-    }
-    tangent.y = 0;
-    if (tangent.lengthSq() === 0) {
-      tangent.set(0, 0, 1);
-    } else {
-      tangent.normalize();
-    }
-
-    return {
-      t: bestSample.t,
-      distance: Math.sqrt(minDistanceSq),
-      closestPoint: bestSample.point.clone(),
-      tangent,
-    };
-  }
-
-  updateHUD() {
-    if (!this.hud.telemetry || !this.level) return;
-
-    const now = this.lastTimestamp;
-    const currentLapSeconds = this.lapStartTime ? (now - this.lapStartTime) / 1000 : 0;
-    const bestLapSeconds = this.bestLapTime ? this.bestLapTime / 1000 : null;
-    const lastLapSeconds = this.lastLapTime ? this.lastLapTime / 1000 : null;
-    const speedKph = Math.abs(this.car.speed) * 3.6;
-    const progressText = `${Math.min(this.activeCheckpoint + 1, this.checkpoints.length)} / ${
-      this.checkpoints.length
-    }`;
-
-    const offTrackText = this.offTrack
-      ? '<span style="color:#ff8a7a;">Off track</span>'
-      : '<span style="color:#78ffd0;">On track</span>';
-
-    const trainingSession = this.trainingSession;
-    const trainingInfo = trainingSession
-      ? `<div><strong>Training:</strong> ${
-          trainingSession.active ? 'Active' : 'Idle'
-        } · Reward ${(trainingSession.lastReward ?? 0).toFixed(3)} · Steps ${
-          trainingSession.steps ?? 0
-        }</div>`
-      : '';
-
-    this.hud.telemetry.innerHTML = `
-      <div><strong>Track:</strong> ${this.level.name} <span style="color:#7f92ff;">(${this.level.difficulty})</span></div>
-      <div><strong>Speed:</strong> ${speedKph.toFixed(1)} km/h</div>
-      <div><strong>Current lap:</strong> ${currentLapSeconds.toFixed(2)} s</div>
-      <div><strong>Last lap:</strong> ${lastLapSeconds ? lastLapSeconds.toFixed(2) + ' s' : '—'}</div>
-      <div><strong>Best lap:</strong> ${bestLapSeconds ? bestLapSeconds.toFixed(2) + ' s' : '—'}</div>
-      <div><strong>Checkpoints:</strong> ${progressText}</div>
-      <div><strong>Track status:</strong> ${offTrackText}</div>
-      <div><strong>Control mode:</strong> ${
-        this.controlMode === 'manual' ? 'Manual (keyboard)' : 'External (AI/script)'
-      }</div>
-      ${trainingInfo}
-    `;
-  }
-
-  _showLapFlash(lapMs) {
-    if (!this.hud.flash) return;
-    const seconds = lapMs / 1000;
-    this.hud.flash.textContent = `Lap ${this.lapTimes.length}: ${seconds.toFixed(2)} s`;
-    this.hud.flash.classList.add('visible');
-    if (this.lapFlashTimeout) {
-      clearTimeout(this.lapFlashTimeout);
-    }
-    this.lapFlashTimeout = setTimeout(() => {
-      this.hud.flash.classList.remove('visible');
-    }, 2200);
-  }
-
-  _updateInstructions() {
-    if (!this.hud.instructions || !this.level) return;
-    this.hud.instructions.innerHTML = `
-      <strong>Track Intel</strong>
-      <div style="margin:0.35rem 0;color:#eaf0ff;">
-        ${this.level.name} · <span style="color:#8aa8ff;">${this.level.difficulty}</span>
-      </div>
-      <div style="margin-bottom:0.8rem;color:#aeb7cd;">${this.level.description}</div>
-      <strong>Manual Driving</strong>
-      <ul>
-        <li><code>W</code>/<code>↑</code> accelerate, <code>S</code>/<code>↓</code> reverse</li>
-        <li><code>A</code>/<code>←</code> steer left, <code>D</code>/<code>→</code> steer right</li>
-        <li><code>Space</code> brake, <code>R</code> reset car</li>
-        <li><code>N</code>/<code>P</code> cycle tracks, <code>C</code> toggle camera</li>
-      </ul>
-      <strong>AI Hooks</strong>
-      <ul>
-        <li>Activate scripted control via <code>window.racingSim.useExternalControls()</code>.</li>
-        <li>Drive the car with <code>setControlInput({ throttle, steer, brake })</code> (range [-1, 1]).</li>
-        <li>Read state snapshots from <code>window.racingSim.getState()</code> for learning loops.</li>
-        <li>Switch tracks through <code>window.racingSim.loadLevel(index)</code>.</li>
-        <li>Start frozen RL episodes via <code>window.racingSim.startEpisode({ levelIndex, stepDuration })</code>.</li>
-        <li>Advance training with <code>stepEpisode(action)</code> to receive reward/done info per step.</li>
-        <li>Inspect normalized observations with <code>getObservation()</code> and progress via <code>getTrainingState()</code>.</li>
-      </ul>
-    `;
-  }
-
-  updateCamera(dt) {
-    if (this.cameraMode === 'overview') {
-      const desired = new THREE.Vector3(this.car.position.x, 36, this.car.position.z + 0.01);
-      this.camera.position.lerp(desired, 1 - Math.exp(-dt * 3));
-      const lookTarget = this.car.position.clone();
-      lookTarget.y += 0.5;
-      this.camera.lookAt(lookTarget);
-      return;
-    }
-
-    const offset = new THREE.Vector3(0, 7.5, 12);
-    offset.applyAxisAngle(new THREE.Vector3(0, 1, 0), this.car.heading);
-    const desiredPosition = this.car.position.clone().add(offset);
-    this.camera.position.lerp(desiredPosition, 1 - Math.exp(-dt * 2.4));
-    const lookAt = this.car.position.clone();
-    lookAt.y += 1.5;
-    this.camera.lookAt(lookAt);
-  }
-
-  update(dt, controlOverride, options = {}) {
-    const { skipHUD = false, skipCamera = false } = options;
-    this.currentTimeMs += dt * 1000;
-    this.lastTimestamp = this.currentTimeMs;
-    this.updatePhysics(dt, controlOverride);
-    this.handleCheckpoints();
-    this.updateOffTrack();
-    if (!skipHUD) {
-      this.updateHUD();
-    }
-    if (!skipCamera) {
-      this.updateCamera(dt);
-    }
-  }
-
-  animate() {
-    requestAnimationFrame(() => this.animate());
-    const now = performance.now();
-    const delta = Math.min((now - this.lastTime) / 1000, 0.1);
-    this.lastTime = now;
-    if (!this.simulationPaused) {
-      this.update(delta);
-    }
-    this.renderer.render(this.scene, this.camera);
-  }
-
-  getStateSnapshot() {
-    const now = this.lastTimestamp;
-    const bestLapSeconds = this.bestLapTime ? this.bestLapTime / 1000 : null;
-    const lastLapSeconds = this.lastLapTime ? this.lastLapTime / 1000 : null;
-    const currentLapSeconds = this.lapStartTime ? (now - this.lapStartTime) / 1000 : null;
-
-    return {
-      timestamp: now,
-      controlMode: this.controlMode,
-      level: {
-        index: this.levelIndex,
-        name: this.level.name,
-        difficulty: this.level.difficulty,
-        width: this.level.width,
-        checkpointRadius: this.level.checkpointRadius,
-        checkpointsRemaining: this.checkpoints.length - this.activeCheckpoint,
-        totalCheckpoints: this.checkpoints.length,
-      },
-      car: {
-        position: { x: this.car.position.x, y: this.car.position.y, z: this.car.position.z },
-        heading: this.car.heading,
-        speed: this.car.speed,
-        steerAngle: this.car.steerAngle,
-      },
-      lap: {
-        lapCount: this.lapTimes.length,
-        currentLapSeconds,
-        lastLapSeconds,
-        bestLapSeconds,
-      },
-      telemetry: {
-        offTrack: this.offTrack,
-        distanceFromCenter: this.distanceFromCenter,
-        speedKph: Math.abs(this.car.speed) * 3.6,
-      },
-    };
-  }
-
-  getObservation({ includeRaw = true, includeNormalized = true } = {}) {
-    if (!this.level) {
-      return { raw: null, normalized: null };
-    }
-
-    const projection =
-      this.lastTrackProjection ?? this._computeTrackProjection(this.car.position);
-
-    const headingVector = new THREE.Vector3(
-      Math.sin(this.car.heading),
-      0,
-      Math.cos(this.car.heading)
-    ).normalize();
-    const tangent = projection.tangent.clone();
-    const headingDot = THREE.MathUtils.clamp(
-      tangent.dot(headingVector),
-      -1,
-      1
-    );
-    const headingCross = tangent.x * headingVector.z - tangent.z * headingVector.x;
-    const headingError = Math.atan2(headingCross, headingDot);
-
-    const lateralOffset = this._computeLateralOffset(projection);
-    const centerScale = this.level ? this.level.width * 1.15 : 1;
-    const normalizedOffset = centerScale ? lateralOffset / centerScale : 0;
-    const distanceNormalized = Math.min(Math.abs(normalizedOffset), 1);
-
-    const nextCheckpoint = this.checkpoints[this.activeCheckpoint];
-    let checkpointDistance = 0;
-    let checkpointDirection = new THREE.Vector3(0, 0, 1);
-    let checkpointAngle = 0;
-    if (nextCheckpoint) {
-      checkpointDirection = nextCheckpoint.position.clone().sub(this.car.position);
-      checkpointDirection.y = 0;
-      checkpointDistance = checkpointDirection.length();
-      if (checkpointDistance > 0) {
-        checkpointDirection.normalize();
-      }
-      const cpDot = THREE.MathUtils.clamp(
-        checkpointDirection.x * headingVector.x + checkpointDirection.z * headingVector.z,
-        -1,
-        1
+  function updateCamera(dt) {
+    if (cameraMode === 'chase') {
+      const rotation = player.rotation.y;
+      const rotatedOffset = new THREE.Vector3(
+        chaseOffset.x * Math.sin(rotation) + chaseOffset.z * Math.cos(rotation),
+        chaseOffset.y,
+        chaseOffset.z * Math.cos(rotation) - chaseOffset.x * Math.sin(rotation)
       );
-      const cpCross =
-        checkpointDirection.x * headingVector.z - checkpointDirection.z * headingVector.x;
-      checkpointAngle = Math.atan2(cpCross, cpDot);
+      const desiredPosition = player.position.clone().add(rotatedOffset);
+      chaseCamera.position.lerp(desiredPosition, 1 - Math.exp(-dt * 4.5));
+      const target = player.position.clone().add(lookOffset);
+      chaseCamera.lookAt(target);
+    } else {
+      orthoCamera.position.x = player.position.x;
+      orthoCamera.position.z = player.position.z;
+      orthoCamera.lookAt(player.position.x, player.position.y, player.position.z);
     }
+  }
 
-    const progress = projection.t;
-    const progressDistance = (this.trackLength ?? 0) * progress;
-    const speedAlongTrack = this.car.speed * Math.cos(headingError);
-    const speedKph = Math.abs(this.car.speed) * 3.6;
+  function updateHUD(dt) {
+    elapsedTime += dt;
+    if (timeEl) {
+      timeEl.textContent = elapsedTime.toFixed(1);
+    }
+  }
 
-    const observation = {};
-    if (includeRaw) {
-      observation.raw = {
-        timestamp: this.lastTimestamp,
-        position: { x: this.car.position.x, y: this.car.position.y, z: this.car.position.z },
-        heading: this.car.heading,
-        steerAngle: this.car.steerAngle,
-        speed: this.car.speed,
-        speedKph,
-        track: {
-          progress,
-          progressDistance,
-          tangent: { x: tangent.x, z: tangent.z },
-          distanceFromCenter: this.distanceFromCenter,
-          lateralOffset,
-        },
-        checkpoint: nextCheckpoint
-          ? {
-              index: nextCheckpoint.index,
-              distance: checkpointDistance,
-              direction: { x: checkpointDirection.x, z: checkpointDirection.z },
-              relativeAngle: checkpointAngle,
-            }
-          : null,
-        lap: {
-          count: this.lapTimes.length,
-          current: this.lapStartTime ? (this.lastTimestamp - this.lapStartTime) / 1000 : 0,
-          best: this.bestLapTime ? this.bestLapTime / 1000 : null,
-          last: this.lastLapTime ? this.lastLapTime / 1000 : null,
-        },
-        offTrack: this.offTrack,
+  function onResize() {
+    const newAspect = window.innerWidth / window.innerHeight;
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    chaseCamera.aspect = newAspect;
+    chaseCamera.updateProjectionMatrix();
+
+    orthoCamera.left = (-orthoSize * newAspect) / 2;
+    orthoCamera.right = (orthoSize * newAspect) / 2;
+    orthoCamera.updateProjectionMatrix();
+  }
+
+  window.addEventListener('resize', onResize);
+
+  function resetGame() {
+    player.position.set(0, 0.45, 0);
+    velocity.set(0, 0, 0);
+    elapsedTime = 0;
+    scatterCollectibles(9);
+    viewEl.textContent = cameraMode === 'chase' ? 'Chase' : 'Top-down';
+  }
+
+  scatterCollectibles(9);
+  viewEl.textContent = 'Chase';
+  if (totalEl) totalEl.textContent = String(collectibles.length);
+  if (scoreEl) scoreEl.textContent = '0';
+
+  function animate() {
+    const dt = clock.getDelta();
+    const time = clock.elapsedTime;
+
+    updatePlayer(dt);
+    updateCollectibles(dt, time);
+    updateCamera(dt);
+    updateHUD(dt);
+
+    renderer.render(scene, activeCamera);
+  }
+
+  renderer.setAnimationLoop(animate);
+
+  const api = {
+    getState() {
+      return {
+        position: { x: player.position.x, y: player.position.y, z: player.position.z },
+        velocity: { x: velocity.x, y: velocity.y, z: velocity.z },
+        collected: Number(scoreEl ? scoreEl.textContent : 0),
+        total: collectibles.length,
+        elapsedTime,
+        view: cameraMode,
       };
-    }
-
-    if (includeNormalized) {
-      const checkpointScale =
-        this.trackLength && this.trackLength > 0
-          ? this.trackLength
-          : Math.max(checkpointDistance, 1);
-      observation.normalized = {
-        speed: THREE.MathUtils.clamp(this.car.speed / this.params.maxSpeed, -1, 1),
-        steer: THREE.MathUtils.clamp(this.car.steerAngle / this.params.maxSteer, -1, 1),
-        distanceFromCenter: distanceNormalized,
-        lateralPosition: THREE.MathUtils.clamp(normalizedOffset, -1.5, 1.5),
-        headingToTrackSin: Math.sin(headingError),
-        headingToTrackCos: Math.cos(headingError),
-        checkpointDirectionSin: Math.sin(checkpointAngle),
-        checkpointDirectionCos: Math.cos(checkpointAngle),
-        checkpointDistance: Math.min(checkpointDistance / checkpointScale, 1),
-        progress,
-        offTrack: this.offTrack ? 1 : 0,
-        speedAlongTrack: THREE.MathUtils.clamp(
-          speedAlongTrack / this.params.maxSpeed,
-          -1,
-          1
-        ),
-      };
-    }
-
-    return observation;
-  }
-
-  pauseSimulation() {
-    this.simulationPaused = true;
-  }
-
-  resumeSimulation() {
-    this.simulationPaused = false;
-    this.lastTime = performance.now();
-  }
-
-  isPaused() {
-    return this.simulationPaused;
-  }
-
-  _mergeTrainingOptions(options = {}) {
-    return {
-      stepDuration:
-        typeof options.stepDuration === 'number' && options.stepDuration > 0
-          ? options.stepDuration
-          : TRAINING_DEFAULTS.stepDuration,
-      reward: {
-        ...TRAINING_DEFAULTS.reward,
-        ...(options.reward || {}),
-      },
-      termination: {
-        ...TRAINING_DEFAULTS.termination,
-        ...(options.termination || {}),
-      },
-    };
-  }
-
-  _calculateProgressDelta(current, previous) {
-    let delta = current - previous;
-    if (delta < -0.5) delta += 1;
-    if (delta > 0.5) delta -= 1;
-    return delta;
-  }
-
-  _computeLateralOffset(projection) {
-    const tangent = projection.tangent.clone();
-    const lateralBasis = new THREE.Vector3(-tangent.z, 0, tangent.x);
-    return this.car.position.clone().sub(projection.closestPoint).dot(lateralBasis);
-  }
-
-  _normalizeAngle(angle) {
-    return THREE.MathUtils.euclideanModulo(angle + Math.PI, Math.PI * 2) - Math.PI;
-  }
-
-  startTrainingEpisode(options = {}) {
-    if (this.trainingSession) {
-      this.trainingSession.active = false;
-      this.trainingSession.done = true;
-    }
-
-    const shouldLoadLevel =
-      typeof options.levelIndex === 'number' && options.levelIndex !== this.levelIndex;
-    if (shouldLoadLevel) {
-      this.loadLevel(options.levelIndex);
-    } else {
-      this.resetCar({ preserveLapTimes: false });
-    }
-
-    this.setControlMode('external');
-    this.externalControl = { throttle: 0, brake: 0, steer: 0 };
-    this.pauseSimulation();
-    this.updateOffTrack();
-    this.updateHUD();
-
-    const mergedOptions = this._mergeTrainingOptions(options);
-
-    this.trainingSession = {
-      active: true,
-      options: mergedOptions,
-      steps: 0,
-      cumulativeReward: 0,
-      lastReward: 0,
-      lastDistanceGain: 0,
-      lastProgress: this.lastTrackProjection.t,
-      lastCheckpointIndex: this.activeCheckpoint,
-      lastLapCount: this.lapTimes.length,
-      consecutiveOffTrackSteps: 0,
-      stepsWithoutProgress: 0,
-      lastAction: { throttle: 0, steer: 0, brake: 0 },
-      startTimeMs: this.currentTimeMs,
-      done: false,
-      doneReasons: [],
-      headless: options.headless ?? false,
-    };
-
-    return this.getObservation();
-  }
-
-  stepTrainingEpisode(action = {}, options = {}) {
-    if (!this.trainingSession) {
-      throw new Error('No active training episode. Call startEpisode() first.');
-    }
-
-    const session = this.trainingSession;
-    if (session.done) {
-      throw new Error('Training episode has finished. Start a new episode.');
-    }
-
-    const dt =
-      typeof options.dt === 'number' && options.dt > 0
-        ? options.dt
-        : session.options.stepDuration;
-
-    const control = this._sanitizeControlInput(action);
-
-    const prevProgress = session.lastProgress;
-    const prevCheckpointIndex = session.lastCheckpointIndex;
-    const prevLapCount = session.lastLapCount;
-
-    const skipHUD = options.skipHUD ?? session.headless;
-    const shouldRender = options.render ?? !session.headless;
-    const skipCamera = options.skipCamera ?? !shouldRender;
-
-    this.update(dt, control, { skipHUD, skipCamera });
-
-    if (shouldRender) {
-      this.renderer.render(this.scene, this.camera);
-    }
-
-    const projection = this.lastTrackProjection ?? this._computeTrackProjection(this.car.position);
-    const progress = projection.t;
-    const progressDelta = this._calculateProgressDelta(progress, prevProgress);
-    const distanceGain = progressDelta * (this.trackLength ?? 0);
-
-    const rewardConfig = session.options.reward;
-    const termination = session.options.termination;
-
-    if (Math.abs(progressDelta) <= termination.progressThreshold) {
-      session.stepsWithoutProgress += 1;
-    } else {
-      session.stepsWithoutProgress = 0;
-    }
-
-    if (this.offTrack) {
-      session.consecutiveOffTrackSteps += 1;
-    } else {
-      session.consecutiveOffTrackSteps = 0;
-    }
-
-    const centerScale = this.level ? this.level.width * 1.15 : 1;
-    const lateralOffset = this._computeLateralOffset(projection);
-    const lateralNormalized = centerScale ? lateralOffset / centerScale : 0;
-    const distancePenalty =
-      Math.pow(Math.min(Math.abs(lateralNormalized), 1), 2) * rewardConfig.centerline;
-    const offTrackPenalty = this.offTrack ? rewardConfig.offTrack : 0;
-    const smoothnessPenalty =
-      rewardConfig.smoothness *
-      Math.abs(control.steer - (session.lastAction ? session.lastAction.steer : 0));
-    const brakePenalty = rewardConfig.brake * control.brake;
-
-    let reward =
-      distanceGain * rewardConfig.progress -
-      distancePenalty -
-      offTrackPenalty -
-      smoothnessPenalty -
-      brakePenalty;
-
-    const lapCompleted = this.lapTimes.length > prevLapCount;
-    const checkpointAdvanced =
-      lapCompleted || this.activeCheckpoint !== prevCheckpointIndex;
-
-    if (checkpointAdvanced) {
-      reward += rewardConfig.checkpointBonus;
-    }
-    if (lapCompleted) {
-      reward += rewardConfig.lapBonus;
-    }
-
-    session.cumulativeReward += reward;
-    session.steps += 1;
-    session.lastReward = reward;
-    session.lastDistanceGain = distanceGain;
-    session.lastAction = control;
-    session.lastProgress = progress;
-    session.lastCheckpointIndex = this.activeCheckpoint;
-    session.lastLapCount = this.lapTimes.length;
-
-    const doneReasons = [];
-    if (session.steps >= termination.maxSteps) doneReasons.push('max_steps');
-    if (session.consecutiveOffTrackSteps >= termination.offTrackSteps)
-      doneReasons.push('off_track_timeout');
-    if (session.stepsWithoutProgress >= termination.noProgressSteps)
-      doneReasons.push('stalled');
-
-    const done = doneReasons.length > 0;
-    session.done = done;
-    session.doneReasons = doneReasons;
-    session.active = !done;
-
-    if (done && options.autoReset) {
-      this.resetCar({ preserveLapTimes: false });
-      this.updateOffTrack();
-      this.pauseSimulation();
-    }
-
-    const observation = options.returnObservation === false ? null : this.getObservation();
-
-    const info = {
-      checkpointAdvanced,
-      lapCompleted,
-      offTrack: this.offTrack,
-      distanceFromCenter: this.distanceFromCenter,
-      distanceGain,
-      progress,
-      cumulativeReward: session.cumulativeReward,
-      steps: session.steps,
-      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
-      doneReasons,
-      speed: this.car.speed,
-    };
-
-    return { observation, reward, done, info };
-  }
-
-  endTrainingEpisode(options = {}) {
-    if (!this.trainingSession) {
-      if (options.resume === true) {
-        this.resumeSimulation();
+    },
+    reset() {
+      resetGame();
+    },
+    toggleView(mode = 'auto') {
+      if (mode === 'chase' || mode === 'orthographic') {
+        setCameraMode(mode);
+      } else {
+        setCameraMode('auto');
       }
-      return null;
-    }
+    },
+    spawnCollectibles(count = 9) {
+      scatterCollectibles(Math.max(1, Math.floor(count)));
+    },
+  };
 
-    const session = this.trainingSession;
-    const summary = {
-      steps: session.steps,
-      cumulativeReward: session.cumulativeReward,
-      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
-      done: session.done,
-      doneReasons: [...(session.doneReasons || [])],
-    };
-
-    session.active = false;
-    if (options.resume === true) {
-      this.resumeSimulation();
-    }
-
-    this.trainingSession = null;
-    this.updateHUD();
-
-    return summary;
-  }
-
-  getTrainingState() {
-    if (!this.trainingSession) return null;
-    const session = this.trainingSession;
-    return {
-      active: session.active,
-      steps: session.steps,
-      cumulativeReward: session.cumulativeReward,
-      lastReward: session.lastReward,
-      lastDistanceGain: session.lastDistanceGain,
-      options: session.options,
-      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
-      done: session.done,
-      doneReasons: session.doneReasons,
-      headless: session.headless,
-    };
-  }
-
-  _onResize() {
-    this.camera.aspect = window.innerWidth / window.innerHeight;
-    this.camera.updateProjectionMatrix();
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-  }
-}
-
-const racingLab = new RacingLab();
-
-window.racingSim = {
-  loadLevel: (index) => racingLab.loadLevel(index),
-  reset: () => racingLab.resetCar({ preserveLapTimes: true }),
-  getState: () => racingLab.getStateSnapshot(),
-  getObservation: (options) => racingLab.getObservation(options),
-  setControlInput: (control) => racingLab.setExternalControl(control),
-  useExternalControls: () => racingLab.setControlMode('external'),
-  useManualControls: () => racingLab.setControlMode('manual'),
-  setCameraMode: (mode) => racingLab.setCameraMode(mode),
-  toggleCameraMode: () => racingLab.toggleCameraMode(),
-  pause: () => racingLab.pauseSimulation(),
-  resume: () => racingLab.resumeSimulation(),
-  isPaused: () => racingLab.isPaused(),
-  startEpisode: (options) => racingLab.startTrainingEpisode(options),
-  stepEpisode: (action, options) => racingLab.stepTrainingEpisode(action, options),
-  endEpisode: (options) => racingLab.endTrainingEpisode(options),
-  getTrainingState: () => racingLab.getTrainingState(),
-  getTrainingDefaults: () => JSON.parse(JSON.stringify(TRAINING_DEFAULTS)),
-  getLevels: () =>
-    TRACK_LEVELS.map((level, index) => ({
-      index,
-      name: level.name,
-      difficulty: level.difficulty,
-      description: level.description,
-    })),
-};
+  window.playgroundSim = api;
+})();

--- a/game/game.js
+++ b/game/game.js
@@ -1,0 +1,1290 @@
+const TRACK_LEVELS = [
+  {
+    name: 'Training Oval',
+    difficulty: 'Novice',
+    description:
+      'Wide, sweeping turns that emphasize smooth throttle control and stable steering. Ideal for baseline policy evaluation.',
+    color: 0x3f7bff,
+    width: 1.9,
+    checkpointRadius: 2.7,
+    spawn: { position: [0, 0.25, -11], heading: 0 },
+    path: [
+      [0, -12],
+      [5, -11],
+      [10, -7],
+      [12, 0],
+      [10, 7],
+      [5, 11],
+      [0, 12],
+      [-5, 11],
+      [-10, 7],
+      [-12, 0],
+      [-10, -7],
+      [-5, -11],
+    ],
+    checkpoints: [
+      [0, -11],
+      [9, 0],
+      [0, 11],
+      [-9, 0],
+    ],
+  },
+  {
+    name: 'Switchback Sprint',
+    difficulty: 'Intermediate',
+    description:
+      'Tight chicanes and hairpins push braking and steering precision. Perfect for experimenting with look-ahead controllers.',
+    color: 0x3ad7a3,
+    width: 1.45,
+    checkpointRadius: 2.2,
+    spawn: { position: [-11, 0.25, -7], heading: Math.PI / 6 },
+    path: [
+      [-12, -8],
+      [-8, -11],
+      [-2, -9],
+      [4, -7],
+      [10, -3],
+      [12, 2],
+      [8, 6],
+      [2, 9],
+      [-4, 10],
+      [-10, 7],
+      [-12, 1],
+      [-8, -3],
+    ],
+    checkpoints: [
+      [-11, -7],
+      [-2, -3],
+      [7, 1],
+      [1, 8],
+      [-8, 5],
+    ],
+  },
+  {
+    name: 'Spiral Gauntlet',
+    difficulty: 'Advanced',
+    description:
+      'A narrowing spiral with sweeping radius changes that reward predictive control policies and adaptive braking strategies.',
+    color: 0xff7a4d,
+    width: 1.15,
+    checkpointRadius: 2.0,
+    spawn: { position: [0, 0.25, -9], heading: 0 },
+    path: [
+      [0, -10],
+      [6, -8],
+      [10, -2],
+      [9, 4],
+      [5, 9],
+      [-1, 10],
+      [-7, 8],
+      [-10, 3],
+      [-9, -3],
+      [-4, -8],
+      [2, -9],
+      [7, -4],
+      [6, 2],
+      [2, 6],
+      [-3, 6],
+      [-6, 2],
+      [-5, -3],
+      [-1, -6],
+      [3, -6],
+      [5, -3],
+      [3, 0],
+      [0, 2],
+      [-2, 0],
+      [-1, -3],
+    ],
+    checkpoints: [
+      [0, -9],
+      [8, -1],
+      [2, 7],
+      [-7, 5],
+      [-2, -5],
+    ],
+  },
+];
+
+const TRAINING_DEFAULTS = {
+  stepDuration: 1 / 60,
+  reward: {
+    progress: 1,
+    centerline: 0.6,
+    offTrack: 4,
+    smoothness: 0.3,
+    brake: 0.2,
+    checkpointBonus: 8,
+    lapBonus: 25,
+  },
+  termination: {
+    offTrackSteps: 120,
+    noProgressSteps: 240,
+    maxSteps: 5400,
+    progressThreshold: 0.0002,
+  },
+};
+
+class RacingLab {
+  constructor() {
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x0f1017);
+    this.scene.fog = new THREE.Fog(0x06070c, 60, 120);
+
+    this.camera = new THREE.PerspectiveCamera(
+      60,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      250
+    );
+    this.camera.position.set(0, 14, 18);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(this.renderer.domElement);
+
+    this.cameraMode = 'follow';
+
+    this.lastTime = performance.now();
+    this.currentTimeMs = 0;
+    this.lastTimestamp = this.currentTimeMs;
+    this.simulationPaused = false;
+    this.trainingSession = null;
+
+    this.lastTrackProjection = {
+      t: 0,
+      distance: 0,
+      closestPoint: new THREE.Vector3(),
+      tangent: new THREE.Vector3(0, 0, 1),
+    };
+
+    this.keys = {};
+    this.externalControl = { throttle: 0, brake: 0, steer: 0 };
+    this.controlMode = 'manual';
+
+    this.params = {
+      acceleration: 10.5,
+      reverseAcceleration: 6.0,
+      brakeStrength: 18,
+      drag: 0.42,
+      rollingResistance: 1.35,
+      offTrackResistance: 7.5,
+      maxSpeed: 22,
+      maxReverseSpeed: 7,
+      maxSteer: THREE.MathUtils.degToRad(34),
+      steerRate: THREE.MathUtils.degToRad(155),
+      wheelBase: 2.6,
+    };
+
+    this._buildEnvironment();
+    this.car = this._buildCar();
+
+    this.checkpointMaterials = {
+      idle: new THREE.MeshStandardMaterial({
+        color: 0x1d2534,
+        transparent: true,
+        opacity: 0.35,
+        metalness: 0.1,
+        roughness: 0.6,
+      }),
+      active: new THREE.MeshStandardMaterial({
+        color: 0xffd166,
+        emissive: 0x7d4b00,
+        emissiveIntensity: 0.7,
+        transparent: true,
+        opacity: 0.85,
+      }),
+      passed: new THREE.MeshStandardMaterial({
+        color: 0x6cf5b3,
+        emissive: 0x0e5431,
+        emissiveIntensity: 0.65,
+        transparent: true,
+        opacity: 0.65,
+      }),
+    };
+
+    this.trackMesh = null;
+    this.startLine = null;
+    this.checkpoints = [];
+    this.trackSamples = [];
+
+    this.activeCheckpoint = 0;
+    this.offTrack = false;
+    this.distanceFromCenter = 0;
+
+    this.lapTimes = [];
+    this.lastLapTime = null;
+    this.bestLapTime = null;
+    this.lapStartTime = null;
+
+    this.hud = {
+      telemetry: document.getElementById('telemetry'),
+      instructions: document.getElementById('instructions'),
+      flash: document.getElementById('lapFlash'),
+    };
+
+    this.lapFlashTimeout = null;
+
+    window.addEventListener('resize', () => this._onResize());
+    window.addEventListener('keydown', (e) => this._handleKeyDown(e));
+    window.addEventListener('keyup', (e) => this._handleKeyUp(e));
+
+    this.loadLevel(0);
+    this.animate();
+  }
+
+  _buildEnvironment() {
+    const ambient = new THREE.AmbientLight(0xb9c5ff, 0.22);
+    const hemi = new THREE.HemisphereLight(0xaec6ff, 0x0b0d13, 0.75);
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    dirLight.position.set(18, 26, 12);
+
+    this.scene.add(ambient, hemi, dirLight);
+
+    const groundGeometry = new THREE.PlaneGeometry(220, 220, 10, 10);
+    const groundMaterial = new THREE.MeshStandardMaterial({
+      color: 0x101522,
+      roughness: 0.9,
+      metalness: 0.05,
+    });
+    const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = 0;
+    this.scene.add(ground);
+
+    const grid = new THREE.GridHelper(220, 110, 0x22304a, 0x131a2b);
+    grid.position.y = 0.01;
+    this.scene.add(grid);
+  }
+
+  _buildCar() {
+    const group = new THREE.Group();
+
+    const chassisGeometry = new THREE.BoxGeometry(1.4, 0.4, 2.6);
+    const chassisMaterial = new THREE.MeshStandardMaterial({
+      color: 0xff5533,
+      metalness: 0.35,
+      roughness: 0.45,
+    });
+    const chassis = new THREE.Mesh(chassisGeometry, chassisMaterial);
+    chassis.position.y = 0.2;
+    group.add(chassis);
+
+    const canopyGeometry = new THREE.BoxGeometry(1.05, 0.35, 1.2);
+    const canopyMaterial = new THREE.MeshStandardMaterial({
+      color: 0xf8f9fb,
+      metalness: 0.1,
+      roughness: 0.2,
+    });
+    const canopy = new THREE.Mesh(canopyGeometry, canopyMaterial);
+    canopy.position.set(0, 0.5, -0.1);
+    group.add(canopy);
+
+    const wheelGeometry = new THREE.CylinderGeometry(0.35, 0.35, 0.25, 22);
+    wheelGeometry.rotateZ(Math.PI / 2);
+    const wheelMaterial = new THREE.MeshStandardMaterial({
+      color: 0x0c0c0f,
+      roughness: 0.9,
+    });
+    const wheelOffsets = [
+      [0.7, 0, 1.1],
+      [-0.7, 0, 1.1],
+      [0.7, 0, -1.1],
+      [-0.7, 0, -1.1],
+    ];
+    wheelOffsets.forEach(([x, y, z]) => {
+      const wheel = new THREE.Mesh(wheelGeometry.clone(), wheelMaterial);
+      wheel.position.set(x, 0.15 + y, z);
+      group.add(wheel);
+    });
+
+    group.position.set(0, 0.25, 0);
+    this.scene.add(group);
+
+    return {
+      mesh: group,
+      position: group.position,
+      speed: 0,
+      heading: 0,
+      steerAngle: 0,
+    };
+  }
+
+  loadLevel(index) {
+    const levelIndex = THREE.MathUtils.euclideanModulo(index, TRACK_LEVELS.length);
+    const level = TRACK_LEVELS[levelIndex];
+
+    if (this.trackMesh) {
+      this.scene.remove(this.trackMesh);
+      this.trackMesh.geometry.dispose();
+      this.trackMesh.material.dispose();
+      this.trackMesh = null;
+    }
+
+    if (this.startLine) {
+      this.scene.remove(this.startLine);
+      this.startLine.geometry.dispose();
+      this.startLine.material.dispose();
+      this.startLine = null;
+    }
+
+    if (this.checkpoints.length) {
+      this.checkpoints.forEach((checkpoint) => {
+        this.scene.remove(checkpoint.mesh);
+        checkpoint.mesh.geometry.dispose();
+      });
+    }
+    this.checkpoints = [];
+
+    this.levelIndex = levelIndex;
+    this.level = level;
+
+    const pathVectors = level.path.map(([x, z]) => new THREE.Vector3(x, 0.05, z));
+    this.levelCurve = new THREE.CatmullRomCurve3(pathVectors, true, 'catmullrom', 0.1);
+    this.trackLength = this.levelCurve.getLength();
+
+    const segments = Math.max(pathVectors.length * 12, 180);
+    const trackGeometry = new THREE.TubeGeometry(
+      this.levelCurve,
+      segments,
+      level.width,
+      24,
+      true
+    );
+    const trackMaterial = new THREE.MeshStandardMaterial({
+      color: level.color,
+      roughness: 0.35,
+      metalness: 0.25,
+      emissive: new THREE.Color(level.color).multiplyScalar(0.1),
+    });
+    this.trackMesh = new THREE.Mesh(trackGeometry, trackMaterial);
+    this.trackMesh.position.y = 0.08;
+    this.trackMesh.scale.y = 0.2;
+    this.scene.add(this.trackMesh);
+
+    this.trackSamples = [];
+    const sampleCount = 720;
+    for (let i = 0; i < sampleCount; i += 1) {
+      const t = i / sampleCount;
+      const point = this.levelCurve.getPointAt(t);
+      this.trackSamples.push({ point, t });
+    }
+
+    const checkpointGeometry = new THREE.CylinderGeometry(
+      level.checkpointRadius,
+      level.checkpointRadius,
+      0.2,
+      32,
+      1,
+      true
+    );
+    level.checkpoints.forEach(([x, z], idx) => {
+      const mesh = new THREE.Mesh(checkpointGeometry.clone(), this.checkpointMaterials.idle);
+      mesh.position.set(x, 0.12, z);
+      mesh.rotation.x = Math.PI / 2;
+      this.scene.add(mesh);
+
+      this.checkpoints.push({
+        index: idx,
+        position: new THREE.Vector3(x, 0.1, z),
+        mesh,
+      });
+    });
+    checkpointGeometry.dispose();
+
+    if (this.checkpoints.length > 1) {
+      const start = this.checkpoints[0].position.clone();
+      const next = this.checkpoints[1].position.clone();
+      const direction = next.clone().sub(start).normalize();
+      const angle = Math.atan2(direction.x, direction.z) + Math.PI / 2;
+      const startGeometry = new THREE.PlaneGeometry(level.width * 2.2, 0.8);
+      const startMaterial = new THREE.MeshBasicMaterial({
+        color: 0xffffff,
+        transparent: true,
+        opacity: 0.55,
+        side: THREE.DoubleSide,
+      });
+      this.startLine = new THREE.Mesh(startGeometry, startMaterial);
+      this.startLine.rotation.x = -Math.PI / 2;
+      this.startLine.rotation.y = angle;
+      this.startLine.position.copy(start);
+      this.startLine.position.y = 0.11;
+      this.scene.add(this.startLine);
+    }
+
+    this.activeCheckpoint = 0;
+    this.offTrack = false;
+    this.distanceFromCenter = 0;
+
+    this.lapTimes = [];
+    this.lastLapTime = null;
+    this.bestLapTime = null;
+    this.lapStartTime = null;
+
+    this._updateInstructions();
+    this.resetCar({ preserveLapTimes: false });
+  }
+
+  resetCar({ preserveLapTimes = true } = {}) {
+    if (!this.level) return;
+
+    const [x, y, z] = this.level.spawn.position;
+    this.car.position.set(x, y, z);
+    this.car.heading = this.level.spawn.heading;
+    this.car.speed = 0;
+    this.car.steerAngle = 0;
+    this.car.mesh.position.copy(this.car.position);
+    this.car.mesh.rotation.set(0, this.car.heading, 0);
+
+    this.activeCheckpoint = 0;
+    this.offTrack = false;
+
+    this.checkpoints.forEach((checkpoint) => {
+      checkpoint.mesh.material = this.checkpointMaterials.idle;
+    });
+    if (this.checkpoints[0]) {
+      this.checkpoints[0].mesh.material = this.checkpointMaterials.active;
+    }
+
+    if (!preserveLapTimes) {
+      this.lapTimes = [];
+      this.lastLapTime = null;
+      this.bestLapTime = null;
+    }
+    this.lapStartTime = this.currentTimeMs;
+  }
+
+  setControlMode(mode) {
+    this.controlMode = mode === 'external' ? 'external' : 'manual';
+    if (this.controlMode === 'manual') {
+      this.externalControl = { throttle: 0, brake: 0, steer: 0 };
+    }
+  }
+
+  setExternalControl(control = {}) {
+    this.externalControl = this._sanitizeControlInput(control);
+    if (control.reset === true) {
+      this.resetCar({ preserveLapTimes: true });
+    }
+  }
+
+  setCameraMode(mode) {
+    this.cameraMode = mode === 'overview' ? 'overview' : 'follow';
+  }
+
+  toggleCameraMode() {
+    this.setCameraMode(this.cameraMode === 'follow' ? 'overview' : 'follow');
+  }
+
+  _handleKeyDown(event) {
+    const key = event.key.toLowerCase();
+    if (
+      ['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' '].includes(key) ||
+      ['w', 'a', 's', 'd'].includes(key)
+    ) {
+      event.preventDefault();
+    }
+
+    switch (key) {
+      case 'r':
+        this.resetCar({ preserveLapTimes: true });
+        return;
+      case 'n':
+        this.loadLevel(this.levelIndex + 1);
+        return;
+      case 'p':
+        this.loadLevel(this.levelIndex - 1);
+        return;
+      case 'm':
+        this.setControlMode('manual');
+        return;
+      case 'g':
+        this.setControlMode('external');
+        return;
+      case 'c':
+        this.toggleCameraMode();
+        return;
+      default:
+        break;
+    }
+
+    this.keys[key] = true;
+  }
+
+  _handleKeyUp(event) {
+    const key = event.key.toLowerCase();
+    this.keys[key] = false;
+  }
+
+  _isKeyActive(key) {
+    return Boolean(this.keys[key]);
+  }
+
+  _sanitizeControlInput(control = {}) {
+    return {
+      throttle: THREE.MathUtils.clamp(
+        control.throttle ?? control.accelerate ?? control.forward ?? 0,
+        -1,
+        1
+      ),
+      brake: THREE.MathUtils.clamp(control.brake ?? control.handbrake ?? 0, 0, 1),
+      steer: THREE.MathUtils.clamp(control.steer ?? control.turn ?? 0, -1, 1),
+    };
+  }
+
+  resolveControls() {
+    if (this.controlMode === 'external') {
+      return { ...this.externalControl };
+    }
+
+    let throttle = 0;
+    if (this._isKeyActive('w') || this._isKeyActive('arrowup')) throttle += 1;
+    if (this._isKeyActive('s') || this._isKeyActive('arrowdown')) throttle -= 1;
+
+    let steer = 0;
+    if (this._isKeyActive('a') || this._isKeyActive('arrowleft')) steer -= 1;
+    if (this._isKeyActive('d') || this._isKeyActive('arrowright')) steer += 1;
+
+    const brake = this._isKeyActive(' ');
+
+    return {
+      throttle: THREE.MathUtils.clamp(throttle, -1, 1),
+      steer: THREE.MathUtils.clamp(steer, -1, 1),
+      brake: brake ? 1 : 0,
+    };
+  }
+
+  updatePhysics(dt, controlOverride) {
+    const controls = controlOverride
+      ? this._sanitizeControlInput(controlOverride)
+      : this.resolveControls();
+    const steerTarget = THREE.MathUtils.clamp(controls.steer, -1, 1) * this.params.maxSteer;
+    const steerDelta = steerTarget - this.car.steerAngle;
+    const maxSteerChange = this.params.steerRate * dt;
+    this.car.steerAngle += THREE.MathUtils.clamp(steerDelta, -maxSteerChange, maxSteerChange);
+
+    const throttleInput = THREE.MathUtils.clamp(controls.throttle ?? 0, -1, 1);
+    const brakeInput = THREE.MathUtils.clamp(controls.brake ?? 0, 0, 1);
+
+    let acceleration = 0;
+    if (throttleInput >= 0) {
+      acceleration += throttleInput * this.params.acceleration;
+    } else {
+      acceleration += throttleInput * this.params.reverseAcceleration;
+    }
+
+    if (brakeInput > 0) {
+      acceleration -= Math.sign(this.car.speed) * brakeInput * this.params.brakeStrength;
+    }
+
+    const drag = this.params.drag * this.car.speed * Math.abs(this.car.speed);
+    const rolling = this.params.rollingResistance * Math.sign(this.car.speed);
+    acceleration -= drag;
+    if (Math.abs(this.car.speed) > 0.05) {
+      acceleration -= rolling;
+    }
+
+    if (this.offTrack) {
+      acceleration -= Math.sign(this.car.speed) * this.params.offTrackResistance;
+    }
+
+    this.car.speed += acceleration * dt;
+    this.car.speed = THREE.MathUtils.clamp(
+      this.car.speed,
+      -this.params.maxReverseSpeed,
+      this.params.maxSpeed
+    );
+    if (Math.abs(this.car.speed) < 0.01 && throttleInput === 0 && brakeInput === 0) {
+      this.car.speed = 0;
+    }
+
+    const forward = new THREE.Vector3(
+      Math.sin(this.car.heading),
+      0,
+      Math.cos(this.car.heading)
+    );
+    this.car.position.addScaledVector(forward, this.car.speed * dt);
+    this.car.position.y = this.level.spawn.position[1];
+
+    const angularVelocity = (this.car.speed / this.params.wheelBase) * Math.tan(this.car.steerAngle);
+    this.car.heading += angularVelocity * dt;
+    this.car.mesh.position.copy(this.car.position);
+    this.car.mesh.rotation.set(0, this.car.heading, 0);
+  }
+
+  handleCheckpoints() {
+    if (!this.level || !this.checkpoints.length) return;
+
+    const checkpoint = this.checkpoints[this.activeCheckpoint];
+    if (!checkpoint) return;
+
+    const distance = checkpoint.position.distanceTo(this.car.position);
+    if (distance <= this.level.checkpointRadius) {
+      checkpoint.mesh.material = this.checkpointMaterials.passed;
+      this.activeCheckpoint += 1;
+
+      if (this.activeCheckpoint >= this.checkpoints.length) {
+        const now = this.currentTimeMs;
+        if (this.lapStartTime) {
+          const lapMs = now - this.lapStartTime;
+          this.lapTimes.push(lapMs);
+          this.lastLapTime = lapMs;
+          this.bestLapTime = this.bestLapTime ? Math.min(this.bestLapTime, lapMs) : lapMs;
+          this._showLapFlash(lapMs);
+        }
+        this.lapStartTime = now;
+        this.activeCheckpoint = 0;
+        this.checkpoints.forEach((cp, idx) => {
+          cp.mesh.material = idx === 0 ? this.checkpointMaterials.active : this.checkpointMaterials.idle;
+        });
+      } else {
+        const nextCheckpoint = this.checkpoints[this.activeCheckpoint];
+        nextCheckpoint.mesh.material = this.checkpointMaterials.active;
+        if (!this.lapStartTime) {
+          this.lapStartTime = this.currentTimeMs;
+        }
+      }
+    }
+  }
+
+  updateOffTrack() {
+    if (!this.trackSamples.length) {
+      this.offTrack = false;
+      this.distanceFromCenter = 0;
+      this.lastTrackProjection = {
+        t: 0,
+        distance: 0,
+        closestPoint: this.car.position.clone(),
+        tangent: new THREE.Vector3(0, 0, 1),
+      };
+      return;
+    }
+
+    const projection = this._computeTrackProjection(this.car.position);
+    this.lastTrackProjection = projection;
+    this.distanceFromCenter = projection.distance;
+    this.offTrack = projection.distance > this.level.width * 1.15;
+  }
+
+  _computeTrackProjection(position = this.car.position) {
+    if (!this.trackSamples.length) {
+      return {
+        t: 0,
+        distance: 0,
+        closestPoint: position.clone(),
+        tangent: new THREE.Vector3(0, 0, 1),
+      };
+    }
+
+    let bestSample = this.trackSamples[0];
+    let minDistanceSq = Infinity;
+    for (let i = 0; i < this.trackSamples.length; i += 1) {
+      const sample = this.trackSamples[i];
+      const dx = position.x - sample.point.x;
+      const dz = position.z - sample.point.z;
+      const distSq = dx * dx + dz * dz;
+      if (distSq < minDistanceSq) {
+        minDistanceSq = distSq;
+        bestSample = sample;
+      }
+    }
+
+    let tangent;
+    if (this.levelCurve && typeof this.levelCurve.getTangentAt === 'function') {
+      tangent = this.levelCurve.getTangentAt(bestSample.t).clone();
+    } else if (this.levelCurve && typeof this.levelCurve.getTangent === 'function') {
+      tangent = this.levelCurve.getTangent(bestSample.t).clone();
+    } else {
+      tangent = new THREE.Vector3(0, 0, 1);
+    }
+    tangent.y = 0;
+    if (tangent.lengthSq() === 0) {
+      tangent.set(0, 0, 1);
+    } else {
+      tangent.normalize();
+    }
+
+    return {
+      t: bestSample.t,
+      distance: Math.sqrt(minDistanceSq),
+      closestPoint: bestSample.point.clone(),
+      tangent,
+    };
+  }
+
+  updateHUD() {
+    if (!this.hud.telemetry || !this.level) return;
+
+    const now = this.lastTimestamp;
+    const currentLapSeconds = this.lapStartTime ? (now - this.lapStartTime) / 1000 : 0;
+    const bestLapSeconds = this.bestLapTime ? this.bestLapTime / 1000 : null;
+    const lastLapSeconds = this.lastLapTime ? this.lastLapTime / 1000 : null;
+    const speedKph = Math.abs(this.car.speed) * 3.6;
+    const progressText = `${Math.min(this.activeCheckpoint + 1, this.checkpoints.length)} / ${
+      this.checkpoints.length
+    }`;
+
+    const offTrackText = this.offTrack
+      ? '<span style="color:#ff8a7a;">Off track</span>'
+      : '<span style="color:#78ffd0;">On track</span>';
+
+    const trainingSession = this.trainingSession;
+    const trainingInfo = trainingSession
+      ? `<div><strong>Training:</strong> ${
+          trainingSession.active ? 'Active' : 'Idle'
+        } · Reward ${(trainingSession.lastReward ?? 0).toFixed(3)} · Steps ${
+          trainingSession.steps ?? 0
+        }</div>`
+      : '';
+
+    this.hud.telemetry.innerHTML = `
+      <div><strong>Track:</strong> ${this.level.name} <span style="color:#7f92ff;">(${this.level.difficulty})</span></div>
+      <div><strong>Speed:</strong> ${speedKph.toFixed(1)} km/h</div>
+      <div><strong>Current lap:</strong> ${currentLapSeconds.toFixed(2)} s</div>
+      <div><strong>Last lap:</strong> ${lastLapSeconds ? lastLapSeconds.toFixed(2) + ' s' : '—'}</div>
+      <div><strong>Best lap:</strong> ${bestLapSeconds ? bestLapSeconds.toFixed(2) + ' s' : '—'}</div>
+      <div><strong>Checkpoints:</strong> ${progressText}</div>
+      <div><strong>Track status:</strong> ${offTrackText}</div>
+      <div><strong>Control mode:</strong> ${
+        this.controlMode === 'manual' ? 'Manual (keyboard)' : 'External (AI/script)'
+      }</div>
+      ${trainingInfo}
+    `;
+  }
+
+  _showLapFlash(lapMs) {
+    if (!this.hud.flash) return;
+    const seconds = lapMs / 1000;
+    this.hud.flash.textContent = `Lap ${this.lapTimes.length}: ${seconds.toFixed(2)} s`;
+    this.hud.flash.classList.add('visible');
+    if (this.lapFlashTimeout) {
+      clearTimeout(this.lapFlashTimeout);
+    }
+    this.lapFlashTimeout = setTimeout(() => {
+      this.hud.flash.classList.remove('visible');
+    }, 2200);
+  }
+
+  _updateInstructions() {
+    if (!this.hud.instructions || !this.level) return;
+    this.hud.instructions.innerHTML = `
+      <strong>Track Intel</strong>
+      <div style="margin:0.35rem 0;color:#eaf0ff;">
+        ${this.level.name} · <span style="color:#8aa8ff;">${this.level.difficulty}</span>
+      </div>
+      <div style="margin-bottom:0.8rem;color:#aeb7cd;">${this.level.description}</div>
+      <strong>Manual Driving</strong>
+      <ul>
+        <li><code>W</code>/<code>↑</code> accelerate, <code>S</code>/<code>↓</code> reverse</li>
+        <li><code>A</code>/<code>←</code> steer left, <code>D</code>/<code>→</code> steer right</li>
+        <li><code>Space</code> brake, <code>R</code> reset car</li>
+        <li><code>N</code>/<code>P</code> cycle tracks, <code>C</code> toggle camera</li>
+      </ul>
+      <strong>AI Hooks</strong>
+      <ul>
+        <li>Activate scripted control via <code>window.racingSim.useExternalControls()</code>.</li>
+        <li>Drive the car with <code>setControlInput({ throttle, steer, brake })</code> (range [-1, 1]).</li>
+        <li>Read state snapshots from <code>window.racingSim.getState()</code> for learning loops.</li>
+        <li>Switch tracks through <code>window.racingSim.loadLevel(index)</code>.</li>
+        <li>Start frozen RL episodes via <code>window.racingSim.startEpisode({ levelIndex, stepDuration })</code>.</li>
+        <li>Advance training with <code>stepEpisode(action)</code> to receive reward/done info per step.</li>
+        <li>Inspect normalized observations with <code>getObservation()</code> and progress via <code>getTrainingState()</code>.</li>
+      </ul>
+    `;
+  }
+
+  updateCamera(dt) {
+    if (this.cameraMode === 'overview') {
+      const desired = new THREE.Vector3(this.car.position.x, 36, this.car.position.z + 0.01);
+      this.camera.position.lerp(desired, 1 - Math.exp(-dt * 3));
+      const lookTarget = this.car.position.clone();
+      lookTarget.y += 0.5;
+      this.camera.lookAt(lookTarget);
+      return;
+    }
+
+    const offset = new THREE.Vector3(0, 7.5, 12);
+    offset.applyAxisAngle(new THREE.Vector3(0, 1, 0), this.car.heading);
+    const desiredPosition = this.car.position.clone().add(offset);
+    this.camera.position.lerp(desiredPosition, 1 - Math.exp(-dt * 2.4));
+    const lookAt = this.car.position.clone();
+    lookAt.y += 1.5;
+    this.camera.lookAt(lookAt);
+  }
+
+  update(dt, controlOverride, options = {}) {
+    const { skipHUD = false, skipCamera = false } = options;
+    this.currentTimeMs += dt * 1000;
+    this.lastTimestamp = this.currentTimeMs;
+    this.updatePhysics(dt, controlOverride);
+    this.handleCheckpoints();
+    this.updateOffTrack();
+    if (!skipHUD) {
+      this.updateHUD();
+    }
+    if (!skipCamera) {
+      this.updateCamera(dt);
+    }
+  }
+
+  animate() {
+    requestAnimationFrame(() => this.animate());
+    const now = performance.now();
+    const delta = Math.min((now - this.lastTime) / 1000, 0.1);
+    this.lastTime = now;
+    if (!this.simulationPaused) {
+      this.update(delta);
+    }
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  getStateSnapshot() {
+    const now = this.lastTimestamp;
+    const bestLapSeconds = this.bestLapTime ? this.bestLapTime / 1000 : null;
+    const lastLapSeconds = this.lastLapTime ? this.lastLapTime / 1000 : null;
+    const currentLapSeconds = this.lapStartTime ? (now - this.lapStartTime) / 1000 : null;
+
+    return {
+      timestamp: now,
+      controlMode: this.controlMode,
+      level: {
+        index: this.levelIndex,
+        name: this.level.name,
+        difficulty: this.level.difficulty,
+        width: this.level.width,
+        checkpointRadius: this.level.checkpointRadius,
+        checkpointsRemaining: this.checkpoints.length - this.activeCheckpoint,
+        totalCheckpoints: this.checkpoints.length,
+      },
+      car: {
+        position: { x: this.car.position.x, y: this.car.position.y, z: this.car.position.z },
+        heading: this.car.heading,
+        speed: this.car.speed,
+        steerAngle: this.car.steerAngle,
+      },
+      lap: {
+        lapCount: this.lapTimes.length,
+        currentLapSeconds,
+        lastLapSeconds,
+        bestLapSeconds,
+      },
+      telemetry: {
+        offTrack: this.offTrack,
+        distanceFromCenter: this.distanceFromCenter,
+        speedKph: Math.abs(this.car.speed) * 3.6,
+      },
+    };
+  }
+
+  getObservation({ includeRaw = true, includeNormalized = true } = {}) {
+    if (!this.level) {
+      return { raw: null, normalized: null };
+    }
+
+    const projection =
+      this.lastTrackProjection ?? this._computeTrackProjection(this.car.position);
+
+    const headingVector = new THREE.Vector3(
+      Math.sin(this.car.heading),
+      0,
+      Math.cos(this.car.heading)
+    ).normalize();
+    const tangent = projection.tangent.clone();
+    const headingDot = THREE.MathUtils.clamp(
+      tangent.dot(headingVector),
+      -1,
+      1
+    );
+    const headingCross = tangent.x * headingVector.z - tangent.z * headingVector.x;
+    const headingError = Math.atan2(headingCross, headingDot);
+
+    const lateralOffset = this._computeLateralOffset(projection);
+    const centerScale = this.level ? this.level.width * 1.15 : 1;
+    const normalizedOffset = centerScale ? lateralOffset / centerScale : 0;
+    const distanceNormalized = Math.min(Math.abs(normalizedOffset), 1);
+
+    const nextCheckpoint = this.checkpoints[this.activeCheckpoint];
+    let checkpointDistance = 0;
+    let checkpointDirection = new THREE.Vector3(0, 0, 1);
+    let checkpointAngle = 0;
+    if (nextCheckpoint) {
+      checkpointDirection = nextCheckpoint.position.clone().sub(this.car.position);
+      checkpointDirection.y = 0;
+      checkpointDistance = checkpointDirection.length();
+      if (checkpointDistance > 0) {
+        checkpointDirection.normalize();
+      }
+      const cpDot = THREE.MathUtils.clamp(
+        checkpointDirection.x * headingVector.x + checkpointDirection.z * headingVector.z,
+        -1,
+        1
+      );
+      const cpCross =
+        checkpointDirection.x * headingVector.z - checkpointDirection.z * headingVector.x;
+      checkpointAngle = Math.atan2(cpCross, cpDot);
+    }
+
+    const progress = projection.t;
+    const progressDistance = (this.trackLength ?? 0) * progress;
+    const speedAlongTrack = this.car.speed * Math.cos(headingError);
+    const speedKph = Math.abs(this.car.speed) * 3.6;
+
+    const observation = {};
+    if (includeRaw) {
+      observation.raw = {
+        timestamp: this.lastTimestamp,
+        position: { x: this.car.position.x, y: this.car.position.y, z: this.car.position.z },
+        heading: this.car.heading,
+        steerAngle: this.car.steerAngle,
+        speed: this.car.speed,
+        speedKph,
+        track: {
+          progress,
+          progressDistance,
+          tangent: { x: tangent.x, z: tangent.z },
+          distanceFromCenter: this.distanceFromCenter,
+          lateralOffset,
+        },
+        checkpoint: nextCheckpoint
+          ? {
+              index: nextCheckpoint.index,
+              distance: checkpointDistance,
+              direction: { x: checkpointDirection.x, z: checkpointDirection.z },
+              relativeAngle: checkpointAngle,
+            }
+          : null,
+        lap: {
+          count: this.lapTimes.length,
+          current: this.lapStartTime ? (this.lastTimestamp - this.lapStartTime) / 1000 : 0,
+          best: this.bestLapTime ? this.bestLapTime / 1000 : null,
+          last: this.lastLapTime ? this.lastLapTime / 1000 : null,
+        },
+        offTrack: this.offTrack,
+      };
+    }
+
+    if (includeNormalized) {
+      const checkpointScale =
+        this.trackLength && this.trackLength > 0
+          ? this.trackLength
+          : Math.max(checkpointDistance, 1);
+      observation.normalized = {
+        speed: THREE.MathUtils.clamp(this.car.speed / this.params.maxSpeed, -1, 1),
+        steer: THREE.MathUtils.clamp(this.car.steerAngle / this.params.maxSteer, -1, 1),
+        distanceFromCenter: distanceNormalized,
+        lateralPosition: THREE.MathUtils.clamp(normalizedOffset, -1.5, 1.5),
+        headingToTrackSin: Math.sin(headingError),
+        headingToTrackCos: Math.cos(headingError),
+        checkpointDirectionSin: Math.sin(checkpointAngle),
+        checkpointDirectionCos: Math.cos(checkpointAngle),
+        checkpointDistance: Math.min(checkpointDistance / checkpointScale, 1),
+        progress,
+        offTrack: this.offTrack ? 1 : 0,
+        speedAlongTrack: THREE.MathUtils.clamp(
+          speedAlongTrack / this.params.maxSpeed,
+          -1,
+          1
+        ),
+      };
+    }
+
+    return observation;
+  }
+
+  pauseSimulation() {
+    this.simulationPaused = true;
+  }
+
+  resumeSimulation() {
+    this.simulationPaused = false;
+    this.lastTime = performance.now();
+  }
+
+  isPaused() {
+    return this.simulationPaused;
+  }
+
+  _mergeTrainingOptions(options = {}) {
+    return {
+      stepDuration:
+        typeof options.stepDuration === 'number' && options.stepDuration > 0
+          ? options.stepDuration
+          : TRAINING_DEFAULTS.stepDuration,
+      reward: {
+        ...TRAINING_DEFAULTS.reward,
+        ...(options.reward || {}),
+      },
+      termination: {
+        ...TRAINING_DEFAULTS.termination,
+        ...(options.termination || {}),
+      },
+    };
+  }
+
+  _calculateProgressDelta(current, previous) {
+    let delta = current - previous;
+    if (delta < -0.5) delta += 1;
+    if (delta > 0.5) delta -= 1;
+    return delta;
+  }
+
+  _computeLateralOffset(projection) {
+    const tangent = projection.tangent.clone();
+    const lateralBasis = new THREE.Vector3(-tangent.z, 0, tangent.x);
+    return this.car.position.clone().sub(projection.closestPoint).dot(lateralBasis);
+  }
+
+  _normalizeAngle(angle) {
+    return THREE.MathUtils.euclideanModulo(angle + Math.PI, Math.PI * 2) - Math.PI;
+  }
+
+  startTrainingEpisode(options = {}) {
+    if (this.trainingSession) {
+      this.trainingSession.active = false;
+      this.trainingSession.done = true;
+    }
+
+    const shouldLoadLevel =
+      typeof options.levelIndex === 'number' && options.levelIndex !== this.levelIndex;
+    if (shouldLoadLevel) {
+      this.loadLevel(options.levelIndex);
+    } else {
+      this.resetCar({ preserveLapTimes: false });
+    }
+
+    this.setControlMode('external');
+    this.externalControl = { throttle: 0, brake: 0, steer: 0 };
+    this.pauseSimulation();
+    this.updateOffTrack();
+    this.updateHUD();
+
+    const mergedOptions = this._mergeTrainingOptions(options);
+
+    this.trainingSession = {
+      active: true,
+      options: mergedOptions,
+      steps: 0,
+      cumulativeReward: 0,
+      lastReward: 0,
+      lastDistanceGain: 0,
+      lastProgress: this.lastTrackProjection.t,
+      lastCheckpointIndex: this.activeCheckpoint,
+      lastLapCount: this.lapTimes.length,
+      consecutiveOffTrackSteps: 0,
+      stepsWithoutProgress: 0,
+      lastAction: { throttle: 0, steer: 0, brake: 0 },
+      startTimeMs: this.currentTimeMs,
+      done: false,
+      doneReasons: [],
+      headless: options.headless ?? false,
+    };
+
+    return this.getObservation();
+  }
+
+  stepTrainingEpisode(action = {}, options = {}) {
+    if (!this.trainingSession) {
+      throw new Error('No active training episode. Call startEpisode() first.');
+    }
+
+    const session = this.trainingSession;
+    if (session.done) {
+      throw new Error('Training episode has finished. Start a new episode.');
+    }
+
+    const dt =
+      typeof options.dt === 'number' && options.dt > 0
+        ? options.dt
+        : session.options.stepDuration;
+
+    const control = this._sanitizeControlInput(action);
+
+    const prevProgress = session.lastProgress;
+    const prevCheckpointIndex = session.lastCheckpointIndex;
+    const prevLapCount = session.lastLapCount;
+
+    const skipHUD = options.skipHUD ?? session.headless;
+    const shouldRender = options.render ?? !session.headless;
+    const skipCamera = options.skipCamera ?? !shouldRender;
+
+    this.update(dt, control, { skipHUD, skipCamera });
+
+    if (shouldRender) {
+      this.renderer.render(this.scene, this.camera);
+    }
+
+    const projection = this.lastTrackProjection ?? this._computeTrackProjection(this.car.position);
+    const progress = projection.t;
+    const progressDelta = this._calculateProgressDelta(progress, prevProgress);
+    const distanceGain = progressDelta * (this.trackLength ?? 0);
+
+    const rewardConfig = session.options.reward;
+    const termination = session.options.termination;
+
+    if (Math.abs(progressDelta) <= termination.progressThreshold) {
+      session.stepsWithoutProgress += 1;
+    } else {
+      session.stepsWithoutProgress = 0;
+    }
+
+    if (this.offTrack) {
+      session.consecutiveOffTrackSteps += 1;
+    } else {
+      session.consecutiveOffTrackSteps = 0;
+    }
+
+    const centerScale = this.level ? this.level.width * 1.15 : 1;
+    const lateralOffset = this._computeLateralOffset(projection);
+    const lateralNormalized = centerScale ? lateralOffset / centerScale : 0;
+    const distancePenalty =
+      Math.pow(Math.min(Math.abs(lateralNormalized), 1), 2) * rewardConfig.centerline;
+    const offTrackPenalty = this.offTrack ? rewardConfig.offTrack : 0;
+    const smoothnessPenalty =
+      rewardConfig.smoothness *
+      Math.abs(control.steer - (session.lastAction ? session.lastAction.steer : 0));
+    const brakePenalty = rewardConfig.brake * control.brake;
+
+    let reward =
+      distanceGain * rewardConfig.progress -
+      distancePenalty -
+      offTrackPenalty -
+      smoothnessPenalty -
+      brakePenalty;
+
+    const lapCompleted = this.lapTimes.length > prevLapCount;
+    const checkpointAdvanced =
+      lapCompleted || this.activeCheckpoint !== prevCheckpointIndex;
+
+    if (checkpointAdvanced) {
+      reward += rewardConfig.checkpointBonus;
+    }
+    if (lapCompleted) {
+      reward += rewardConfig.lapBonus;
+    }
+
+    session.cumulativeReward += reward;
+    session.steps += 1;
+    session.lastReward = reward;
+    session.lastDistanceGain = distanceGain;
+    session.lastAction = control;
+    session.lastProgress = progress;
+    session.lastCheckpointIndex = this.activeCheckpoint;
+    session.lastLapCount = this.lapTimes.length;
+
+    const doneReasons = [];
+    if (session.steps >= termination.maxSteps) doneReasons.push('max_steps');
+    if (session.consecutiveOffTrackSteps >= termination.offTrackSteps)
+      doneReasons.push('off_track_timeout');
+    if (session.stepsWithoutProgress >= termination.noProgressSteps)
+      doneReasons.push('stalled');
+
+    const done = doneReasons.length > 0;
+    session.done = done;
+    session.doneReasons = doneReasons;
+    session.active = !done;
+
+    if (done && options.autoReset) {
+      this.resetCar({ preserveLapTimes: false });
+      this.updateOffTrack();
+      this.pauseSimulation();
+    }
+
+    const observation = options.returnObservation === false ? null : this.getObservation();
+
+    const info = {
+      checkpointAdvanced,
+      lapCompleted,
+      offTrack: this.offTrack,
+      distanceFromCenter: this.distanceFromCenter,
+      distanceGain,
+      progress,
+      cumulativeReward: session.cumulativeReward,
+      steps: session.steps,
+      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
+      doneReasons,
+      speed: this.car.speed,
+    };
+
+    return { observation, reward, done, info };
+  }
+
+  endTrainingEpisode(options = {}) {
+    if (!this.trainingSession) {
+      if (options.resume === true) {
+        this.resumeSimulation();
+      }
+      return null;
+    }
+
+    const session = this.trainingSession;
+    const summary = {
+      steps: session.steps,
+      cumulativeReward: session.cumulativeReward,
+      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
+      done: session.done,
+      doneReasons: [...(session.doneReasons || [])],
+    };
+
+    session.active = false;
+    if (options.resume === true) {
+      this.resumeSimulation();
+    }
+
+    this.trainingSession = null;
+    this.updateHUD();
+
+    return summary;
+  }
+
+  getTrainingState() {
+    if (!this.trainingSession) return null;
+    const session = this.trainingSession;
+    return {
+      active: session.active,
+      steps: session.steps,
+      cumulativeReward: session.cumulativeReward,
+      lastReward: session.lastReward,
+      lastDistanceGain: session.lastDistanceGain,
+      options: session.options,
+      elapsedTime: (this.currentTimeMs - session.startTimeMs) / 1000,
+      done: session.done,
+      doneReasons: session.doneReasons,
+      headless: session.headless,
+    };
+  }
+
+  _onResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+}
+
+const racingLab = new RacingLab();
+
+window.racingSim = {
+  loadLevel: (index) => racingLab.loadLevel(index),
+  reset: () => racingLab.resetCar({ preserveLapTimes: true }),
+  getState: () => racingLab.getStateSnapshot(),
+  getObservation: (options) => racingLab.getObservation(options),
+  setControlInput: (control) => racingLab.setExternalControl(control),
+  useExternalControls: () => racingLab.setControlMode('external'),
+  useManualControls: () => racingLab.setControlMode('manual'),
+  setCameraMode: (mode) => racingLab.setCameraMode(mode),
+  toggleCameraMode: () => racingLab.toggleCameraMode(),
+  pause: () => racingLab.pauseSimulation(),
+  resume: () => racingLab.resumeSimulation(),
+  isPaused: () => racingLab.isPaused(),
+  startEpisode: (options) => racingLab.startTrainingEpisode(options),
+  stepEpisode: (action, options) => racingLab.stepTrainingEpisode(action, options),
+  endEpisode: (options) => racingLab.endTrainingEpisode(options),
+  getTrainingState: () => racingLab.getTrainingState(),
+  getTrainingDefaults: () => JSON.parse(JSON.stringify(TRAINING_DEFAULTS)),
+  getLevels: () =>
+    TRACK_LEVELS.map((level, index) => ({
+      index,
+      name: level.name,
+      difficulty: level.difficulty,
+      description: level.description,
+    })),
+};

--- a/game/index.html
+++ b/game/index.html
@@ -1,130 +1,111 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AgenticSeek Racing Lab</title>
-  <style>
-    :root {
-      color-scheme: dark;
-      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
-    }
-
-    body {
-      margin: 0;
-      overflow: hidden;
-      background: radial-gradient(circle at top, #151b28 0%, #090b12 60%, #040507 100%);
-      color: #f5f7fb;
-    }
-
-    canvas {
-      display: block;
-    }
-
-    #hud {
-      position: absolute;
-      top: 0;
-      left: 0;
-      padding: 20px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      max-width: min(420px, 90vw);
-      pointer-events: none;
-    }
-
-    #title {
-      font-size: 1.4rem;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      color: #9dd5ff;
-      text-shadow: 0 0 12px rgba(82, 191, 255, 0.35);
-    }
-
-    .panel {
-      background: rgba(10, 15, 25, 0.75);
-      border: 1px solid rgba(90, 140, 255, 0.25);
-      border-radius: 12px;
-      padding: 14px 16px;
-      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
-      pointer-events: auto;
-    }
-
-    #telemetry {
-      line-height: 1.5;
-      font-size: 0.95rem;
-      color: #e8ebf4;
-    }
-
-    #telemetry strong {
-      color: #a8d1ff;
-    }
-
-    #lapFlash {
-      opacity: 0;
-      transition: opacity 0.4s ease;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      color: #ffe8a0;
-      text-shadow: 0 0 18px rgba(255, 208, 85, 0.6);
-    }
-
-    #lapFlash.visible {
-      opacity: 1;
-    }
-
-    #instructions {
-      font-size: 0.9rem;
-      line-height: 1.55;
-      color: #c3c8d8;
-    }
-
-    #instructions ul {
-      margin: 0.35rem 0 0.55rem 1.2rem;
-      padding: 0;
-    }
-
-    #instructions li {
-      margin-bottom: 0.25rem;
-    }
-
-    code {
-      font-family: "JetBrains Mono", "Fira Code", monospace;
-      background: rgba(157, 213, 255, 0.1);
-      padding: 0.05rem 0.35rem;
-      border-radius: 6px;
-      color: #9dd5ff;
-    }
-
-    @media (max-width: 640px) {
-      #hud {
-        padding: 12px;
-        gap: 10px;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AgenticSeek Three.js Playground</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
       }
 
-      #title {
-        font-size: 1.2rem;
+      body {
+        margin: 0;
+        overflow: hidden;
+        background: radial-gradient(circle at top, #0b1221 0%, #05070e 55%, #020309 100%);
+        color: #f3f6ff;
       }
 
-      .panel {
-        padding: 12px;
+      #gameCanvas {
+        width: 100vw;
+        height: 100vh;
+        display: block;
       }
 
-      #telemetry {
-        font-size: 0.9rem;
+      #overlay {
+        position: fixed;
+        top: 24px;
+        left: 24px;
+        right: 24px;
+        max-width: 420px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 18px 20px;
+        background: linear-gradient(160deg, rgba(12, 20, 36, 0.82), rgba(7, 12, 24, 0.72));
+        border: 1px solid rgba(109, 173, 255, 0.32);
+        border-radius: 14px;
+        box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+        pointer-events: none;
       }
-    }
-  </style>
-</head>
-<body>
-  <div id="hud">
-    <div id="title">AgenticSeek Racing Lab</div>
-    <div id="telemetry" class="panel"></div>
-    <div id="lapFlash" class="panel"></div>
-    <div id="instructions" class="panel"></div>
-  </div>
-  <script src="https://unpkg.com/three@0.155/build/three.min.js"></script>
-  <script src="game.js"></script>
-</body>
+
+      #overlay h1 {
+        font-size: 1.35rem;
+        margin: 0;
+        color: #8ecaff;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      #stats,
+      #viewMode {
+        font-size: 0.95rem;
+        letter-spacing: 0.01em;
+        color: #dbe6ff;
+      }
+
+      #message {
+        min-height: 1.1rem;
+        font-size: 0.95rem;
+        color: #ffe5a5;
+      }
+
+      #instructions {
+        font-size: 0.88rem;
+        line-height: 1.55;
+        color: #c5d4f7;
+      }
+
+      #instructions strong {
+        color: #9dd5ff;
+      }
+
+      @media (max-width: 640px) {
+        #overlay {
+          top: 12px;
+          left: 12px;
+          right: 12px;
+          padding: 16px;
+          gap: 10px;
+        }
+
+        #overlay h1 {
+          font-size: 1.15rem;
+        }
+
+        #stats,
+        #viewMode {
+          font-size: 0.88rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="gameCanvas"></canvas>
+    <div id="overlay">
+      <h1>AgenticSeek Three.js Playground</h1>
+      <div id="stats">
+        Time <span id="timeValue">0.0</span>s • Shards <span id="scoreValue">0</span>/<span id="totalValue">0</span>
+      </div>
+      <div id="viewMode">View: <span id="viewLabel">Chase</span></div>
+      <div id="message"></div>
+      <div id="instructions">
+        <p><strong>Move</strong> with WASD or the arrow keys. Hold <strong>Shift</strong> to boost and tap <strong>Space</strong> to brake.</p>
+        <p><strong>Press V</strong> to toggle between the 3D chase camera and the top-down tactical view. Hit <strong>R</strong> to respawn collectibles.</p>
+      </div>
+    </div>
+    <script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
+    <script src="game.js"></script>
+  </body>
 </html>

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AgenticSeek Racing Lab</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      overflow: hidden;
+      background: radial-gradient(circle at top, #151b28 0%, #090b12 60%, #040507 100%);
+      color: #f5f7fb;
+    }
+
+    canvas {
+      display: block;
+    }
+
+    #hud {
+      position: absolute;
+      top: 0;
+      left: 0;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: min(420px, 90vw);
+      pointer-events: none;
+    }
+
+    #title {
+      font-size: 1.4rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #9dd5ff;
+      text-shadow: 0 0 12px rgba(82, 191, 255, 0.35);
+    }
+
+    .panel {
+      background: rgba(10, 15, 25, 0.75);
+      border: 1px solid rgba(90, 140, 255, 0.25);
+      border-radius: 12px;
+      padding: 14px 16px;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+      pointer-events: auto;
+    }
+
+    #telemetry {
+      line-height: 1.5;
+      font-size: 0.95rem;
+      color: #e8ebf4;
+    }
+
+    #telemetry strong {
+      color: #a8d1ff;
+    }
+
+    #lapFlash {
+      opacity: 0;
+      transition: opacity 0.4s ease;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      color: #ffe8a0;
+      text-shadow: 0 0 18px rgba(255, 208, 85, 0.6);
+    }
+
+    #lapFlash.visible {
+      opacity: 1;
+    }
+
+    #instructions {
+      font-size: 0.9rem;
+      line-height: 1.55;
+      color: #c3c8d8;
+    }
+
+    #instructions ul {
+      margin: 0.35rem 0 0.55rem 1.2rem;
+      padding: 0;
+    }
+
+    #instructions li {
+      margin-bottom: 0.25rem;
+    }
+
+    code {
+      font-family: "JetBrains Mono", "Fira Code", monospace;
+      background: rgba(157, 213, 255, 0.1);
+      padding: 0.05rem 0.35rem;
+      border-radius: 6px;
+      color: #9dd5ff;
+    }
+
+    @media (max-width: 640px) {
+      #hud {
+        padding: 12px;
+        gap: 10px;
+      }
+
+      #title {
+        font-size: 1.2rem;
+      }
+
+      .panel {
+        padding: 12px;
+      }
+
+      #telemetry {
+        font-size: 0.9rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="hud">
+    <div id="title">AgenticSeek Racing Lab</div>
+    <div id="telemetry" class="panel"></div>
+    <div id="lapFlash" class="panel"></div>
+    <div id="instructions" class="panel"></div>
+  </div>
+  <script src="https://unpkg.com/three@0.155/build/three.min.js"></script>
+  <script src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend the racing sandbox with an episodic training API, pauseable stepping, richer observations, and reward/termination logic for RL loops
- expose new helpers on `window.racingSim` (startEpisode/stepEpisode/endEpisode, getObservation, pause/resume, training defaults) and surface training status in the HUD
- document the training workflow and sample usage in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_686b7af8afd8832bb3d29003f434fa21